### PR TITLE
Entering portals adds dimension

### DIFF
--- a/src/main/java/com/github/hotm/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/hotm/mixin/MinecraftServerMixin.java
@@ -1,10 +1,26 @@
 package com.github.hotm.mixin;
 
 import com.github.hotm.mixinapi.DimensionAdditions;
+import com.github.hotm.mixinapi.MutableMinecraftServer;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.WorldGenerationProgressListener;
+import net.minecraft.server.WorldGenerationProgressListenerFactory;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.RegistryTracker;
 import net.minecraft.world.SaveProperties;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.source.BiomeAccess;
+import net.minecraft.world.border.WorldBorder;
+import net.minecraft.world.border.WorldBorderListener;
+import net.minecraft.world.dimension.DimensionOptions;
+import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.level.UnmodifiableLevelProperties;
+import net.minecraft.world.level.storage.LevelStorage;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -12,27 +28,72 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
 /**
  * Mixin to handle forcing the generation of the nectere dimension.
- *
+ * <p>
  * This is only useful for retroactively generating the nectere dimension in a pre-existing world.
  */
 @SuppressWarnings("unused")
 @Mixin(MinecraftServer.class)
-public class MinecraftServerMixin {
+public abstract class MinecraftServerMixin implements MutableMinecraftServer {
+    @Shadow
+    @Final
+    protected RegistryTracker.Modifiable dimensionTracker;
+
     @Shadow
     @Final
     protected SaveProperties saveProperties;
 
-    @Inject(method = "createWorlds", at = @At("HEAD"))
-    private void onCreateWorlds(WorldGenerationProgressListener listener, CallbackInfo ci) {
-        if (DimensionAdditions.shouldForceDimensions()) {
-            System.out.println("################");
-            System.out.println("Forcing HotM dimension loading.");
-            System.out.println("################");
+    @Shadow
+    @Final
+    protected LevelStorage.Session session;
 
-            GeneratorOptions options = saveProperties.getGeneratorOptions();
-            DimensionAdditions.setupDimensionOptions(options.getSeed(), options.getDimensionMap());
-        }
+    @Shadow
+    @Final
+    private Executor workerExecutor;
+
+    @Shadow
+    @Final
+    private WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory;
+
+    @Shadow
+    @Final
+    private Map<RegistryKey<World>, ServerWorld> worlds;
+
+    @Override
+    public long hotm_getSeed() {
+        return saveProperties.getGeneratorOptions().getSeed();
+    }
+
+    @Override
+    public void hotm_addDimension(RegistryKey<DimensionOptions> optionsKey, DimensionOptions dimensionOptions) {
+        // transmute this into a MinecraftServer
+        Object selfObj = this;
+        MinecraftServer self = (MinecraftServer) selfObj;
+
+        GeneratorOptions generatorOptions = saveProperties.getGeneratorOptions();
+        WorldBorder worldBorder =
+                Objects.requireNonNull(self.getWorld(World.OVERWORLD), "Missing Overworld?!").getWorldBorder();
+        WorldGenerationProgressListener listener = worldGenerationProgressListenerFactory.create(11);
+
+        RegistryKey<World> worldKey = RegistryKey.of(Registry.DIMENSION, optionsKey.getValue());
+        DimensionType dimensionType = dimensionOptions.getDimensionType();
+        RegistryKey<DimensionType> typeKey =
+                dimensionTracker.getDimensionTypeRegistry().getKey(dimensionType).orElseThrow(() -> {
+                    throw new IllegalStateException("Attempting to add unregistered dimension type: " + dimensionType);
+                });
+        ChunkGenerator chunkGenerator = dimensionOptions.getChunkGenerator();
+        UnmodifiableLevelProperties levelProperties =
+                new UnmodifiableLevelProperties(saveProperties, saveProperties.getMainWorldProperties());
+        ServerWorld world =
+                new ServerWorld(self, workerExecutor, session, levelProperties, worldKey, typeKey, dimensionType,
+                        listener, chunkGenerator, generatorOptions.isDebugWorld(),
+                        BiomeAccess.hashSeed(generatorOptions.getSeed()), ImmutableList.of(), false);
+        worldBorder.addListener(new WorldBorderListener.WorldBorderSyncer(world.getWorldBorder()));
+        worlds.put(worldKey, world);
     }
 }

--- a/src/main/java/com/github/hotm/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/hotm/mixin/MinecraftServerMixin.java
@@ -1,6 +1,5 @@
 package com.github.hotm.mixin;
 
-import com.github.hotm.mixinapi.DimensionAdditions;
 import com.github.hotm.mixinapi.MutableMinecraftServer;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.server.MinecraftServer;
@@ -24,9 +23,6 @@ import net.minecraft.world.level.storage.LevelStorage;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Map;
 import java.util.Objects;
@@ -82,10 +78,9 @@ public abstract class MinecraftServerMixin implements MutableMinecraftServer {
 
         RegistryKey<World> worldKey = RegistryKey.of(Registry.DIMENSION, optionsKey.getValue());
         DimensionType dimensionType = dimensionOptions.getDimensionType();
-        RegistryKey<DimensionType> typeKey =
-                dimensionTracker.getDimensionTypeRegistry().getKey(dimensionType).orElseThrow(() -> {
-                    throw new IllegalStateException("Attempting to add unregistered dimension type: " + dimensionType);
-                });
+        RegistryKey<DimensionType> typeKey = dimensionTracker.getDimensionTypeRegistry().getKey(dimensionType)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Attempting to add unregistered dimension type: " + dimensionType));
         ChunkGenerator chunkGenerator = dimensionOptions.getChunkGenerator();
         UnmodifiableLevelProperties levelProperties =
                 new UnmodifiableLevelProperties(saveProperties, saveProperties.getMainWorldProperties());

--- a/src/main/java/com/github/hotm/mixinapi/DimensionAdditions.java
+++ b/src/main/java/com/github/hotm/mixinapi/DimensionAdditions.java
@@ -24,8 +24,6 @@ import java.util.*;
  * Used to register a new dimension with the dimension mixin.
  */
 public class DimensionAdditions {
-    public static final String FORCE_DIMENSION_FLAG = "force-hotm";
-
     private static final List<DimensionAddition> ADDITIONS = new ArrayList<>();
     private static final Map<RegistryKey<DimensionOptions>, DimensionAddition> DIMENSION_KEYS = new HashMap<>();
     private static final Map<RegistryKey<World>, String> SAVE_DIRS = new HashMap<>();
@@ -137,14 +135,9 @@ public class DimensionAdditions {
         return true;
     }
 
-    public static boolean shouldForceDimensions() {
-        File flag = new File(FORCE_DIMENSION_FLAG);
-        if (flag.exists()) {
-            if (!flag.delete()) {
-                System.err.println("Error deleting force dimension flag file: " + flag.getAbsolutePath());
-            }
-            return true;
-        }
-        return false;
+    public static void addDimensionToServer(MutableMinecraftServer server, RegistryKey<DimensionOptions> optionsKey) {
+        DimensionAddition addition = DIMENSION_KEYS.get(optionsKey);
+        server.hotm_addDimension(optionsKey, new DimensionOptions(addition::getDimensionType,
+                addition.getChunkGeneratorSupplier().getChunkGenerator(server.hotm_getSeed())));
     }
 }

--- a/src/main/java/com/github/hotm/mixinapi/MutableMinecraftServer.java
+++ b/src/main/java/com/github/hotm/mixinapi/MutableMinecraftServer.java
@@ -1,0 +1,13 @@
+package com.github.hotm.mixinapi;
+
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.dimension.DimensionOptions;
+
+/**
+ * Interface for a minecraft server that can have worlds added to it.
+ */
+public interface MutableMinecraftServer {
+    long hotm_getSeed();
+
+    void hotm_addDimension(RegistryKey<DimensionOptions> optionsKey, DimensionOptions dimensionOptions);
+}

--- a/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
+++ b/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
@@ -4,6 +4,7 @@ import com.github.hotm.HotMBlocks
 import com.github.hotm.HotMConstants
 import com.github.hotm.HotMLog
 import com.github.hotm.mixinapi.DimensionAdditions
+import com.github.hotm.mixinapi.MutableMinecraftServer
 import net.fabricmc.fabric.api.dimension.v1.FabricDimensions
 import net.minecraft.block.Blocks
 import net.minecraft.block.pattern.BlockPattern
@@ -11,10 +12,6 @@ import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.tag.BlockTags
-import net.minecraft.text.LiteralText
-import net.minecraft.text.Style
-import net.minecraft.text.TextColor
-import net.minecraft.text.TranslatableText
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.registry.Registry
@@ -157,22 +154,15 @@ object HotMDimensions {
                     server.getWorld(World.OVERWORLD)
                 ) { oldEntity, destination, _, _, _ -> findTeleportationDestination(oldEntity, destination) }
             } else {
+                if (server.getWorld(NECTERE_KEY) == null && entity is PlayerEntity && server is MutableMinecraftServer) {
+                    HotMLog.log.info("A player has walked through a nectere portal. Adding the Nectere dimension...")
+                    DimensionAdditions.addDimensionToServer(server, NECTERE_OPTIONS_KEY)
+                }
+
                 val nectereWorld = server.getWorld(NECTERE_KEY)
 
                 if (nectereWorld == null) {
-                    if (entity is PlayerEntity) {
-                        entity.sendMessage(
-                            TranslatableText(
-                                "error.chat.missing_nectere",
-                                LiteralText(DimensionAdditions.FORCE_DIMENSION_FLAG).setStyle(
-                                    Style.EMPTY.withItalic(true).withColor(TextColor.fromRgb(0x0000FF))
-                                )
-                            ).setStyle(Style.EMPTY.withColor(TextColor.fromRgb(0xFF0000))), false
-                        )
-                    }
-
-                    HotMLog.log.warn("An entity is attempting to travel through a Nectere portal, but the Nectere dimension does not exist in this world!")
-                    HotMLog.log.warn("In order to create the Nectere dimension, place a file called 'force-hotm' in the same directory as the server's server.jar file and restart the server.")
+                    HotMLog.log.error("Unable to add the Nectere dimension!")
                 } else {
                     entity.changeDimension(nectereWorld)
                 }

--- a/src/main/resources/assets/hotm/lang/en_us.json
+++ b/src/main/resources/assets/hotm/lang/en_us.json
@@ -34,6 +34,5 @@
   "block.hotm.thinking_stone_brick_stairs": "Thinking Stone Brick Stairs",
   "block.hotm.thinking_stone_tiles": "Thinking Stone Tiles",
   "block.hotm.thinking_stone_tile_slab": "Thinking Stone Tile Slab",
-  "block.hotm.thinking_stone_tile_stairs": "Thinking Stone Tile Stairs",
-  "error.chat.missing_nectere": "The Nectere dimension appears to be missing in this server's world. You can force the server to create it by creating a file named '%s' in the same directory as the server.jar file and restarting the server. Then Nectere portals and the Nectere dimension should work properly."
+  "block.hotm.thinking_stone_tile_stairs": "Thinking Stone Tile Stairs"
 }

--- a/src/main/resources/hotm.mixins.json
+++ b/src/main/resources/hotm.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "DimensionOptionsMixin",
     "DimensionTypeMixin",
+    "MinecraftServerMixin",
     "StructuresConfigMixin",
     "ChunkGeneratorTypeInvoker",
     "DimensionTypeInvoker",
@@ -14,7 +15,6 @@
   "client": [
   ],
   "server": [
-    "MinecraftServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This pull request makes it so that any world that is missing the Nectere dimension will automatically get one when a player tries to enter a Nectere Portal.

This is a potential fix for #3.