### PR TITLE
Fix biome issues encountered when upgrading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.3
 yarn_mappings=1.16.3+build.47
 loader_version=0.10.6+build.214
 #Fabric api
-fabric_version=0.25.0+build.415-1.16
+fabric_version=0.28.0+1.16
 loom_version=0.4-SNAPSHOT
 # Mod Properties
 mod_version=1.16.3-0.1.7-SNAPSHOT

--- a/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
+++ b/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
@@ -422,6 +422,8 @@ object HotMDimensions {
                         currentPos.z.toDouble() / nectereBiome.coordinateMultiplier
                     )
 
+                    // make sure the chunk is loaded
+                    nectereWorld.getBlockState(newPos)
                     if (nectereBiome.biome == nectereWorld.method_31081(newPos).orElse(null)) {
                         Stream.of(newPos)
                     } else {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,8 +31,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.9.2",
-    "fabric": "*",
-    "fabric-language-kotlin": "*",
+    "fabric": ">=0.28.0",
+    "fabric-language-kotlin": ">=1.4.0+build.1",
     "minecraft": "1.16.x"
   }
 }


### PR DESCRIPTION
This fixes the biome issues encountered when upgrading HOTM from 1.16.2 to 1.16.3. These issues were actually caused by the addition of AE2 as a runtime dependency (to make sure the meteorite issues are gone), which added a new biome for the AE2 dimension, causing the biome ids to get reshuffled and breaking the Nectere's biome ids. The new required version of fabric fixes the biome issue.