### PR TITLE
Missing dimension fix

### DIFF
--- a/changelogs/changelog-1.16.3-0.1.7.md
+++ b/changelogs/changelog-1.16.3-0.1.7.md
@@ -3,3 +3,4 @@ For Minecraft 1.16.3.
 
 * Updated to Minecraft 1.16.3.
 * Changed biomes to have category NONE.
+* Fixed a bug which caused dimensions to get deleted when upgrading between minecraft versions.

--- a/src/main/java/com/github/hotm/mixin/CompoundListAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/CompoundListAccessor.java
@@ -7,9 +7,9 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(CompoundList.class)
 public interface CompoundListAccessor {
-    @Accessor
+    @Accessor(remap = false)
     TypeTemplate getKey();
 
-    @Accessor
+    @Accessor(remap = false)
     TypeTemplate getElement();
 }

--- a/src/main/java/com/github/hotm/mixin/CompoundListAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/CompoundListAccessor.java
@@ -1,0 +1,15 @@
+package com.github.hotm.mixin;
+
+import com.mojang.datafixers.types.templates.CompoundList;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CompoundList.class)
+public interface CompoundListAccessor {
+    @Accessor
+    TypeTemplate getKey();
+
+    @Accessor
+    TypeTemplate getElement();
+}

--- a/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
+++ b/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
@@ -1,0 +1,27 @@
+package com.github.hotm.mixin;
+
+import com.github.hotm.mixinapi.DimensionAdditions;
+import com.mojang.datafixers.DataFix;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.templates.TaggedChoice;
+import net.minecraft.datafixer.fix.MissingDimensionFix;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(MissingDimensionFix.class)
+public abstract class MissingDimensionFixMixin extends DataFix {
+    public MissingDimensionFixMixin(Schema outputSchema, boolean changesType) {
+        super(outputSchema, changesType);
+    }
+
+    @ModifyVariable(method = "makeRule", name = "taggedChoiceType", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/datafixer/schema/IdentifierNormalizingSchema;getIdentifierType()Lcom/mojang/datafixers/types/Type;",
+            remap = false))
+    private TaggedChoice.TaggedChoiceType<String> onMakeRuleEditTaggedChoiceType(
+            TaggedChoice.TaggedChoiceType<String> taggedChoiceType) {
+        Schema schema = getInputSchema();
+
+        return DimensionAdditions.injectChunkGeneratorTypes(taggedChoiceType, schema);
+    }
+}

--- a/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
+++ b/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
@@ -3,7 +3,7 @@ package com.github.hotm.mixin;
 import com.github.hotm.mixinapi.DimensionAdditions;
 import com.mojang.datafixers.DataFix;
 import com.mojang.datafixers.schemas.Schema;
-import com.mojang.datafixers.types.templates.TaggedChoice;
+import com.mojang.datafixers.types.templates.CompoundList;
 import net.minecraft.datafixer.fix.MissingDimensionFix;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,13 +15,15 @@ public abstract class MissingDimensionFixMixin extends DataFix {
         super(outputSchema, changesType);
     }
 
-    @ModifyVariable(method = "makeRule", name = "taggedChoiceType", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/datafixer/schema/IdentifierNormalizingSchema;getIdentifierType()Lcom/mojang/datafixers/types/Type;",
+    @ModifyVariable(method = "makeRule", name = "compoundListType", at = @At(value = "INVOKE",
+            target = "Lcom/mojang/datafixers/DSL;compoundList(Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/types/Type;)Lcom/mojang/datafixers/types/templates/CompoundList$CompoundListType;",
+            shift = At.Shift.BY,
+            by = 2,
             remap = false))
-    private TaggedChoice.TaggedChoiceType<String> onMakeRuleEditTaggedChoiceType(
-            TaggedChoice.TaggedChoiceType<String> taggedChoiceType) {
+    private CompoundList.CompoundListType<String, ?> onMakeRuleEditCompoundListType(
+            CompoundList.CompoundListType<String, ?> compoundListType) {
         Schema schema = getInputSchema();
 
-        return DimensionAdditions.injectChunkGeneratorTypes(taggedChoiceType, schema);
+        return DimensionAdditions.injectChunkGeneratorTypes(compoundListType, schema);
     }
 }

--- a/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
+++ b/src/main/java/com/github/hotm/mixin/MissingDimensionFixMixin.java
@@ -15,10 +15,8 @@ public abstract class MissingDimensionFixMixin extends DataFix {
         super(outputSchema, changesType);
     }
 
-    @ModifyVariable(method = "makeRule", name = "compoundListType", at = @At(value = "INVOKE",
+    @ModifyVariable(method = "makeRule", at = @At(value = "INVOKE_ASSIGN",
             target = "Lcom/mojang/datafixers/DSL;compoundList(Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/types/Type;)Lcom/mojang/datafixers/types/templates/CompoundList$CompoundListType;",
-            shift = At.Shift.BY,
-            by = 2,
             remap = false))
     private CompoundList.CompoundListType<String, ?> onMakeRuleEditCompoundListType(
             CompoundList.CompoundListType<String, ?> compoundListType) {

--- a/src/main/java/com/github/hotm/mixin/ProductAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/ProductAccessor.java
@@ -7,9 +7,9 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(Product.class)
 public interface ProductAccessor {
-    @Accessor
+    @Accessor(remap = false)
     TypeTemplate getF();
 
-    @Accessor
+    @Accessor(remap = false)
     TypeTemplate getG();
 }

--- a/src/main/java/com/github/hotm/mixin/ProductAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/ProductAccessor.java
@@ -1,0 +1,15 @@
+package com.github.hotm.mixin;
+
+import com.mojang.datafixers.types.templates.Product;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Product.class)
+public interface ProductAccessor {
+    @Accessor
+    TypeTemplate getF();
+
+    @Accessor
+    TypeTemplate getG();
+}

--- a/src/main/java/com/github/hotm/mixin/Schema2551Mixin.java
+++ b/src/main/java/com/github/hotm/mixin/Schema2551Mixin.java
@@ -1,0 +1,18 @@
+package com.github.hotm.mixin;
+
+import com.github.hotm.mixinapi.DimensionAdditions;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import net.minecraft.datafixer.schema.Schema2551;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Schema2551.class)
+public class Schema2551Mixin {
+    @Inject(method = "method_28297", at = @At("RETURN"))
+    private static void onMethod_28297(Schema schema, CallbackInfoReturnable<TypeTemplate> cir) {
+        DimensionAdditions.injectChunkGeneratorSchema(cir.getReturnValue(), schema);
+    }
+}

--- a/src/main/java/com/github/hotm/mixin/TagAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/TagAccessor.java
@@ -7,12 +7,12 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(Tag.class)
 public interface TagAccessor {
-    @Accessor
+    @Accessor(remap = false)
     String getName();
 
-    @Accessor
+    @Accessor(remap = false)
     TypeTemplate getElement();
 
-    @Accessor
+    @Accessor(remap = false)
     void setElement(TypeTemplate element);
 }

--- a/src/main/java/com/github/hotm/mixin/TagAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/TagAccessor.java
@@ -1,0 +1,18 @@
+package com.github.hotm.mixin;
+
+import com.mojang.datafixers.types.templates.Tag;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Tag.class)
+public interface TagAccessor {
+    @Accessor
+    String getName();
+
+    @Accessor
+    TypeTemplate getElement();
+
+    @Accessor
+    void setElement(TypeTemplate element);
+}

--- a/src/main/java/com/github/hotm/mixin/TaggedChoiceAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/TaggedChoiceAccessor.java
@@ -1,0 +1,21 @@
+package com.github.hotm.mixin;
+
+import com.mojang.datafixers.types.Type;
+import com.mojang.datafixers.types.templates.TaggedChoice;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(TaggedChoice.class)
+public interface TaggedChoiceAccessor<K> {
+    @Accessor
+    String getName();
+
+    @Accessor
+    Type<K> getKeyType();
+
+    @Accessor
+    Map<K, TypeTemplate> getTemplates();
+}

--- a/src/main/java/com/github/hotm/mixin/TaggedChoiceAccessor.java
+++ b/src/main/java/com/github/hotm/mixin/TaggedChoiceAccessor.java
@@ -10,12 +10,12 @@ import java.util.Map;
 
 @Mixin(TaggedChoice.class)
 public interface TaggedChoiceAccessor<K> {
-    @Accessor
+    @Accessor(remap = false)
     String getName();
 
-    @Accessor
+    @Accessor(remap = false)
     Type<K> getKeyType();
 
-    @Accessor
+    @Accessor(remap = false)
     Map<K, TypeTemplate> getTemplates();
 }

--- a/src/main/java/com/github/hotm/prelaunch/HeartOfTheMachineModPreLaunch.java
+++ b/src/main/java/com/github/hotm/prelaunch/HeartOfTheMachineModPreLaunch.java
@@ -1,0 +1,16 @@
+package com.github.hotm.prelaunch;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class HeartOfTheMachineModPreLaunch implements PreLaunchEntrypoint {
+    @Override
+    public void onPreLaunch() {
+        try {
+            PreLaunchHacks.hackilyLoadForMixin("com.mojang.datafixers.kinds.App");
+        } catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/hotm/prelaunch/PreLaunchHacks.java
+++ b/src/main/java/com/github/hotm/prelaunch/PreLaunchHacks.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 i509VCB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Note: This class has been moved into the com.github.hotm.prelaunch package.
+ */
+package com.github.hotm.prelaunch;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+/**
+ * So you want to Mixin into Authlib/Brigadier/DataFixerUpper, on Fabric you'll need this guy.
+ *
+ * <p>YOU SHOULD ONLY USE THIS CLASS DURING "preLaunch" and ONLY TARGET A CLASS WHICH IS NOT ANY CLASS YOU MIXIN TO.
+ *
+ * This will likely not work on Gson because FabricLoader has some special logic related to Gson.
+ */
+public final class PreLaunchHacks {
+    private PreLaunchHacks() {}
+
+    private static final ClassLoader KNOT_CLASSLOADER = Thread.currentThread().getContextClassLoader();
+    private static final Method ADD_URL_METHOD;
+
+    static {
+        Method tempAddUrlMethod = null;
+        try {
+            tempAddUrlMethod = KNOT_CLASSLOADER.getClass().getMethod("addURL", URL.class);
+            tempAddUrlMethod.setAccessible(true);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to load Classloader fields", e);
+        }
+
+        ADD_URL_METHOD = tempAddUrlMethod;
+    }
+
+    /**
+     * Hackily load the package which a mixin may exist within.
+     *
+     * YOU SHOULD NOT TARGET A CLASS WHICH YOU MIXIN TO.
+     *
+     * @param pathOfAClass The path of any class within the package.
+     */
+    public static void hackilyLoadForMixin(String pathOfAClass) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException {
+        URL url = Class.forName(pathOfAClass).getProtectionDomain().getCodeSource().getLocation();
+        ADD_URL_METHOD.invoke(KNOT_CLASSLOADER, url);
+    }
+}

--- a/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
+++ b/src/main/kotlin/com/github/hotm/gen/HotMDimensions.kt
@@ -13,14 +13,8 @@ import com.github.hotm.mixin.StructureFeatureAccessor
 import com.github.hotm.mixinapi.DimensionAdditions
 import com.google.common.collect.HashMultimap
 import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableMap
-import com.mojang.datafixers.DSL
-import com.mojang.datafixers.schemas.Schema
-import com.mojang.datafixers.types.Type
-import com.mojang.datafixers.types.templates.TypeTemplate
 import com.mojang.datafixers.util.Pair
 import net.minecraft.block.Blocks
-import net.minecraft.datafixer.TypeReferences
 import net.minecraft.entity.Entity
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.world.ServerWorld
@@ -193,95 +187,6 @@ object HotMDimensions {
             seed,
             { generatorSettings.getOrThrow(NECTERE_CHUNK_GENERATOR_SETTINGS_KEY) },
             biomes
-        )
-    }
-
-    /**
-     * Adds the Nectere chunk generator schema to the Schema2551's `TypeReferences.CHUNK_GENERATOR_SETTINGS` type registration.
-     */
-    fun injectChunkGeneratorSchema(schema: Schema, builder: ImmutableMap.Builder<String, TypeTemplate>) {
-        builder.put(
-            "hotm:nectere",
-            DSL.optionalFields(
-                "biome_source", DSL.taggedChoiceLazy(
-                    "type", DSL.string(),
-                    ImmutableMap.of("minecraft:fixed",
-                        Supplier { DSL.fields("biome", TypeReferences.BIOME.`in`(schema)) },
-                        "minecraft:multi_noise",
-                        Supplier { DSL.list(DSL.fields("biome", TypeReferences.BIOME.`in`(schema))) },
-                        "minecraft:checkerboard",
-                        Supplier { DSL.fields("biomes", DSL.list(TypeReferences.BIOME.`in`(schema))) },
-                        "minecraft:vanilla_layered", Supplier { DSL.remainder() }, "minecraft:the_end",
-                        Supplier { DSL.remainder() })
-                ), "settings", DSL.or(
-                    DSL.constType(DSL.string()),
-                    DSL.optionalFields(
-                        "default_block", TypeReferences.BLOCK_NAME.`in`(schema),
-                        "default_fluid", TypeReferences.BLOCK_NAME.`in`(schema)
-                    )
-                )
-            )
-        )
-    }
-
-    /**
-     * Adds the Nectere chunk generator schema to the MissingDimensionFix's set of chunk generator schemas.
-     */
-    fun injectChunkGeneratorTypes(schema: Schema, builder: ImmutableMap.Builder<String, Type<*>>) {
-        builder.put(
-            "hotm:nectere",
-            DSL.and(
-                DSL.optional(
-                    DSL.field(
-                        "biome_source",
-                        DSL.taggedChoiceType(
-                            "type", DSL.string(), ImmutableMap.of(
-                                "minecraft:fixed", DSL.and(
-                                    DSL.field("biome", schema.getType(TypeReferences.BIOME)),
-                                    DSL.remainderType()
-                                ),
-                                "minecraft:multi_noise", DSL.list(
-                                    DSL.and(
-                                        DSL.field("biome", schema.getType(TypeReferences.BIOME)),
-                                        DSL.remainderType()
-                                    )
-                                ),
-                                "minecraft:checkerboard", DSL.and(
-                                    DSL.field(
-                                        "biomes",
-                                        DSL.list(schema.getType(TypeReferences.BIOME))
-                                    ),
-                                    DSL.remainderType()
-                                ),
-                                "minecraft:vanilla_layered", DSL.remainderType(),
-                                "minecraft:the_end", DSL.remainderType()
-                            )
-                        )
-                    )
-                ),
-                DSL.optional(
-                    DSL.field(
-                        "settings",
-                        DSL.or(
-                            DSL.string(), DSL.and(
-                                DSL.optional(
-                                    DSL.field(
-                                        "default_block",
-                                        schema.getType(TypeReferences.BLOCK_NAME)
-                                    )
-                                ),
-                                DSL.optional(
-                                    DSL.field(
-                                        "default_fluid",
-                                        schema.getType(TypeReferences.BLOCK_NAME)
-                                    )
-                                ),
-                                DSL.remainderType()
-                            )
-                        )
-                    )
-                ), DSL.remainderType()
-            )
         )
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,9 @@
 
   "environment": "*",
   "entrypoints": {
+    "preLaunch": [
+      "com.github.hotm.prelaunch.HeartOfTheMachineModPreLaunch"
+    ],
     "main": [
       "com.github.hotm.HeartOfTheMachineModKt::init"
     ],

--- a/src/main/resources/hotm.mixins.json
+++ b/src/main/resources/hotm.mixins.json
@@ -10,16 +10,22 @@
     "GenerationSettingsBuilderMixin",
     "LivingEntityMixin",
     "MinecraftServerMixin",
+    "MissingDimensionFixMixin",
+    "Schema2551Mixin",
     "StructuresConfigMixin",
     "ChunkGeneratorSettingsInvoker",
     "DimensionTypeInvoker",
     "MultiNoiseBiomeSourceInvoker",
     "StairsBlockInvoker",
     "BuiltinBiomesAccessor",
+    "CompoundListAccessor",
     "DecoratorContextAccessor",
     "EntityAccessor",
+    "ProductAccessor",
     "StructureFeatureAccessor",
-    "StructurePieceAccessor"
+    "StructurePieceAccessor",
+    "TagAccessor",
+    "TaggedChoiceAccessor"
   ],
   "client": [
   ],


### PR DESCRIPTION
When upgrading a world from one minecraft version to another, the some of the world upgrading systems (possibly `MissingDimensionFix`) choke on modded chunk generator types, causing all vanilla, non-overworld dimensions to be removed from the world. This pull request helps the minecraft dimension fixers to care less about extra chunk generators.