### PR TITLE
Cleanup version numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - '*.*.*-*.*.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/changelogs/changelog-0.2.0.md
+++ b/changelogs/changelog-0.2.0.md
@@ -1,0 +1,2 @@
+# Version 0.2.0
+For Minecraft 1.16.3.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.10.8
 fabric_version=0.28.0+1.16
 loom_version=0.5-SNAPSHOT
 # Mod Properties
-mod_version=1.16.3-0.2.x
+mod_version=0.2.0-SNAPSHOT
 maven_group=com.github.hotm
 archives_base_name=heart-of-the-machine
 mod_release_type=beta


### PR DESCRIPTION
This removes the mod's associated Minecraft version from the mod's version number. Having the Minecraft version be a part of the mod version can be helpful when reading file, but is not very Semver compliant and can mess up anything that attempts to determine the mod's version from its version number.