### PR TITLE
ClassLoader-based mocking in unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     testImplementation "io.kotest:kotest-assertions-core:${project.kotest_version}"
     testImplementation "io.kotest:kotest-extensions-allure:${project.kotest_version}"
     testImplementation "io.mockk:mockk:${project.mockk_version}"
+    testImplementation "org.objenesis:objenesis:${project.objenesis_version}"
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,4 @@ allure_version=2.13.9
 allure_plugin_version=2.8.1
 kotest_version=4.4.3
 mockk_version=1.11.0
+objenesis_version=3.2

--- a/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunk.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunk.kt
@@ -219,6 +219,10 @@ class ServerAuraNetChunk(
             }
         }
 
+        if (removed.isNotEmpty()) {
+            updateSave = true
+        }
+
         for (node in removed.values) {
             node.onRemove()
 

--- a/src/test/kotlin/com/github/hotm/ClassLoaderUtils.kt
+++ b/src/test/kotlin/com/github/hotm/ClassLoaderUtils.kt
@@ -1,0 +1,22 @@
+package com.github.hotm
+
+import io.kotest.core.spec.style.FunSpec
+
+interface RunInSpec {
+    fun run(spec: FunSpec)
+}
+
+inline fun FunSpec.runInMockCL(crossinline toRun: FunSpec.() -> Unit) {
+    val cl = MockClassLoader.instance
+    val runnable = object : RunInSpec {
+        override fun run(spec: FunSpec) {
+            spec.toRun()
+        }
+    }
+    val runnableClass = runnable.javaClass
+    val alteredClass = cl.loadClass(runnableClass.name)
+    val runnable2 = MockClassLoader.OBJENISIS.newInstance(alteredClass)
+    val runMethod = alteredClass.getMethod("run", FunSpec::class.java)
+    runMethod.isAccessible = true
+    runMethod.invoke(runnable2, this)
+}

--- a/src/test/kotlin/com/github/hotm/EmptyClassLoader.kt
+++ b/src/test/kotlin/com/github/hotm/EmptyClassLoader.kt
@@ -1,0 +1,239 @@
+package com.github.hotm
+
+import org.objectweb.asm.*
+import org.objectweb.asm.commons.GeneratorAdapter
+import org.objectweb.asm.commons.Method
+import org.objenesis.Objenesis
+import org.objenesis.ObjenesisStd
+import java.io.File
+import java.io.IOException
+
+class EmptyClassLoader : ClassLoader() {
+    companion object {
+        @JvmStatic
+        val OBJENISIS: Objenesis = ObjenesisStd()
+    }
+
+    override fun loadClass(name: String, resolve: Boolean): Class<*> {
+        synchronized(getClassLoadingLock(name)) {
+            var c = findLoadedClass(name)
+
+            if (c == null
+                && !name.startsWith("java.")
+                && !name.startsWith("jdk.")
+                && !name.startsWith("sun.")
+                && !name.startsWith("io.kotest")
+                && !name.startsWith("kotlin")
+            ) {
+                loadClassBytecode(name)?.let { input ->
+                    val pkgDelimiterPos = name.lastIndexOf('.')
+                    if (pkgDelimiterPos > 0) {
+                        val pkgString = name.substring(0, pkgDelimiterPos)
+                        if (getDefinedPackage(pkgString) == null) {
+                            definePackage(pkgString, null, null, null, null, null, null, null)
+                        }
+                    }
+
+                    c = defineClass(name, input, 0, input.size)
+                }
+            }
+
+            if (c == null) {
+                c = parent.loadClass(name)
+            }
+
+            if (resolve) {
+                resolveClass(c)
+            }
+
+            return c
+        }
+    }
+
+    private fun loadClassBytecode(name: String): ByteArray? {
+        try {
+            val reader =
+                ClassReader(javaClass.classLoader.getResourceAsStream(name.replace('.', File.separatorChar) + ".class"))
+            val writer = ClassWriter(ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
+//        val printer = TraceClassVisitor(writer, PrintWriter(System.out))
+
+            if (name.startsWith("net.minecraft")) {
+                val emptier = EmptyClassVisitor(writer)
+                reader.accept(emptier, ClassReader.EXPAND_FRAMES)
+            } else {
+                reader.accept(writer, ClassReader.EXPAND_FRAMES)
+            }
+
+            return writer.toByteArray()
+        } catch (e: IOException) {
+            System.err.println("Error loading class: $name")
+            return null
+        }
+    }
+
+    class EmptyClassVisitor(cv: ClassVisitor) : ClassVisitor(Opcodes.ASM9, cv) {
+        private var superType = Type.getType(Object::class.java)
+
+        override fun visit(
+            version: Int,
+            access: Int,
+            name: String?,
+            signature: String?,
+            superName: String?,
+            interfaces: Array<out String>?
+        ) {
+            super.visit(version, access, name, signature, superName, interfaces)
+            superName?.let {
+                superType = Type.getObjectType(it)
+            }
+        }
+
+        override fun visitMethod(
+            access: Int,
+            name: String,
+            descriptor: String,
+            signature: String?,
+            exceptions: Array<out String>?
+        ): MethodVisitor {
+            val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+            return EmptyMethodVisitor(
+                access,
+                name,
+                descriptor,
+                mv,
+                superType,
+                "<clinit>" != name
+            )
+        }
+    }
+
+    class EmptyMethodVisitor(
+        private val access: Int,
+        private val name: String,
+        descriptor: String,
+        mv: MethodVisitor,
+        superType: Type,
+        private val except: Boolean
+    ) : MethodVisitor(Opcodes.ASM9, if (name == "<init>") mv else null) {
+        private val method = Method(name, descriptor)
+        private val ga = GeneratorAdapter(access, method, mv)
+        override fun visitParameter(name: String, access: Int) {
+            ga.visitParameter(name, access)
+        }
+
+        override fun visitAnnotationDefault(): AnnotationVisitor {
+            return ga.visitAnnotationDefault()
+        }
+
+        override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor {
+            return ga.visitAnnotation(descriptor, visible)
+        }
+
+        override fun visitTypeAnnotation(
+            typeRef: Int,
+            typePath: TypePath,
+            descriptor: String,
+            visible: Boolean
+        ): AnnotationVisitor {
+            return ga.visitTypeAnnotation(typeRef, typePath, descriptor, visible)
+        }
+
+        override fun visitAnnotableParameterCount(parameterCount: Int, visible: Boolean) {
+            ga.visitAnnotableParameterCount(parameterCount, visible)
+        }
+
+        override fun visitParameterAnnotation(
+            parameter: Int,
+            descriptor: String,
+            visible: Boolean
+        ): AnnotationVisitor {
+            return ga.visitParameterAnnotation(parameter, descriptor, visible)
+        }
+
+        override fun visitAttribute(attribute: Attribute) {
+            ga.visitAttribute(attribute)
+        }
+
+        override fun visitCode() {
+            ga.visitCode()
+        }
+
+        override fun visitMethodInsn(
+            opcode: Int,
+            owner: String?,
+            name: String?,
+            descriptor: String?,
+            isInterface: Boolean
+        ) {
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+            if (name == "<init>") {
+                mv = null
+            }
+        }
+
+        override fun visitEnd() {
+            if (access and Opcodes.ACC_ABSTRACT == 0) {
+                ga.mark()
+
+                if (except) {
+                    val reType = Type.getType(RuntimeException::class.java)
+                    ga.throwException(reType, "Encountered stub method")
+                } else {
+                    when (method.returnType.sort) {
+                        Type.VOID -> {
+                            ga.visitInsn(Opcodes.RETURN)
+                        }
+                        Type.BOOLEAN -> {
+                            ga.push(false)
+                            ga.returnValue()
+                        }
+                        Type.CHAR -> {
+                            ga.push(20)
+                            ga.returnValue()
+                        }
+                        Type.BYTE -> {
+                            ga.push(0)
+                            ga.returnValue()
+                        }
+                        Type.SHORT -> {
+                            ga.push(0)
+                            ga.returnValue()
+                        }
+                        Type.INT -> {
+                            ga.push(0)
+                            ga.returnValue()
+                        }
+                        Type.FLOAT -> {
+                            ga.push(0f)
+                            ga.returnValue()
+                        }
+                        Type.LONG -> {
+                            ga.push(0L)
+                            ga.returnValue()
+                        }
+                        Type.DOUBLE -> {
+                            ga.push(0.0)
+                            ga.returnValue()
+                        }
+                        Type.ARRAY -> {
+                            ga.push(0)
+                            ga.newArray(method.returnType.elementType)
+                            ga.returnValue()
+                        }
+                        Type.OBJECT -> {
+                            val clType = Type.getType(EmptyClassLoader::class.java)
+                            val objType = Type.getType(Objenesis::class.java)
+                            ga.getStatic(clType, "OBJENESIS", objType)
+                            ga.push(method.returnType)
+                            ga.invokeInterface(objType, Method.getMethod("Object newInstance (Class)"))
+                            ga.checkCast(method.returnType)
+                            ga.returnValue()
+                        }
+                    }
+                }
+            }
+
+            ga.endMethod()
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hotm/MockClassLoader.kt
+++ b/src/test/kotlin/com/github/hotm/MockClassLoader.kt
@@ -5,7 +5,6 @@ import org.objectweb.asm.commons.GeneratorAdapter
 import org.objectweb.asm.commons.Method
 import org.objenesis.Objenesis
 import org.objenesis.ObjenesisStd
-import java.io.File
 import java.io.IOException
 
 class MockClassLoader : ClassLoader() {

--- a/src/test/kotlin/com/github/hotm/MockClassLoader.kt
+++ b/src/test/kotlin/com/github/hotm/MockClassLoader.kt
@@ -52,7 +52,7 @@ class MockClassLoader : ClassLoader() {
     private fun loadClassBytecode(name: String): ByteArray? {
         try {
             val reader =
-                ClassReader(javaClass.classLoader.getResourceAsStream(name.replace('.', File.separatorChar) + ".class"))
+                ClassReader(javaClass.classLoader.getResourceAsStream(name.replace('.', '/') + ".class"))
             val writer = ClassWriter(ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
 
             if (ALTERED_EXEMPT.find { name.startsWith(it) } != null) {

--- a/src/test/kotlin/com/github/hotm/MockClassLoader.kt
+++ b/src/test/kotlin/com/github/hotm/MockClassLoader.kt
@@ -65,6 +65,7 @@ class MockClassLoader : ClassLoader() {
             return writer.toByteArray()
         } catch (e: IOException) {
             System.err.println("Error loading class: $name")
+            e.printStackTrace()
             return null
         }
     }

--- a/src/test/kotlin/com/github/hotm/MockClassLoader.kt
+++ b/src/test/kotlin/com/github/hotm/MockClassLoader.kt
@@ -28,7 +28,7 @@ class MockClassLoader : ClassLoader() {
                     val pkgDelimiterPos = name.lastIndexOf('.')
                     if (pkgDelimiterPos > 0) {
                         val pkgString = name.substring(0, pkgDelimiterPos)
-                        if (getDefinedPackage(pkgString) == null) {
+                        if (getPackage(pkgString) == null) {
                             definePackage(pkgString, null, null, null, null, null, null, null)
                         }
                     }

--- a/src/test/kotlin/com/github/hotm/TestProjectConfig.kt
+++ b/src/test/kotlin/com/github/hotm/TestProjectConfig.kt
@@ -1,19 +1,8 @@
 package com.github.hotm
 
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.core.extensions.ConstructorExtension
-import io.kotest.core.spec.Spec
 import io.kotest.extensions.allure.AllureTestReporter
-import kotlin.reflect.KClass
 
 class TestProjectConfig : AbstractProjectConfig() {
     override fun listeners() = listOf(AllureTestReporter())
-    override fun extensions() = listOf(ClassLoaderConstructorExtension)
-}
-
-object ClassLoaderConstructorExtension : ConstructorExtension {
-    override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
-        val cl = EmptyClassLoader()
-        return cl.loadClass(clazz.qualifiedName).newInstance() as Spec?
-    }
 }

--- a/src/test/kotlin/com/github/hotm/TestProjectConfig.kt
+++ b/src/test/kotlin/com/github/hotm/TestProjectConfig.kt
@@ -1,8 +1,19 @@
 package com.github.hotm
 
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.ConstructorExtension
+import io.kotest.core.spec.Spec
 import io.kotest.extensions.allure.AllureTestReporter
+import kotlin.reflect.KClass
 
 class TestProjectConfig : AbstractProjectConfig() {
     override fun listeners() = listOf(AllureTestReporter())
+    override fun extensions() = listOf(ClassLoaderConstructorExtension)
+}
+
+object ClassLoaderConstructorExtension : ConstructorExtension {
+    override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
+        val cl = EmptyClassLoader()
+        return cl.loadClass(clazz.qualifiedName).newInstance() as Spec?
+    }
 }

--- a/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
+++ b/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
@@ -1,149 +1,155 @@
 package com.github.hotm.world.auranet.server
 
-import com.github.hotm.EmptyClassLoader
+import com.github.hotm.blocks.AuraNodeBlock
+import com.github.hotm.runInMockCL
 import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.world.auranet.AuraNodeType
 import com.github.hotm.world.auranet.SiphonAuraNode
 import com.github.hotm.world.auranet.SourceAuraNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
+import net.minecraft.block.BlockState
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.math.BlockPos
 
 class ServerAuraNetChunkTests : FunSpec({
-    isolationMode = IsolationMode.InstancePerTest
+    runInMockCL {
+        isolationMode = IsolationMode.InstancePerTest
 
-    context("Context: Basic ServerAuraNetChunk") {
-        val chunk = ServerAuraNetChunk({}, 64, listOf())
+        context("Context: Basic ServerAuraNetChunk") {
+            val chunk = ServerAuraNetChunk({}, 64, listOf())
 
-        test("Gives base aura") {
-            chunk.getBaseAura() shouldBe 64
+            test("Gives base aura") {
+                chunk.getBaseAura() shouldBe 64
 
-            chunk.setBaseAura(32)
-            chunk.getBaseAura() shouldBe 32
+                chunk.setBaseAura(32)
+                chunk.getBaseAura() shouldBe 32
+            }
         }
-    }
 
-    context("Context: With a basic updateListener") {
-        val updateListener = mockk<Runnable>()
-        every { updateListener.run() } just Runs
-        val node = mockk<AuraNode>()
-        every { node.pos } returns BlockPos(0, 0, 0)
-        every { node.onRemove() } just Runs
-
-//        val cl = EmptyClassLoader()
-//        val runnable = Runnable {
+        context("Context: With a basic updateListener") {
+            val updateListener = mockk<Runnable>()
+            every { updateListener.run() } just Runs
+            val nodeType = mockk<AuraNodeType<*>>()
+            val node = mockk<AuraNode>()
+            every { node.pos } returns BlockPos(0, 0, 0)
+            every { node.onRemove() } just Runs
             val world = mockk<ServerWorld>()
-            println("WORLD: $world")
-//        }
-//        val runnableClass = runnable.javaClass
-//        println("Runnable class: $runnableClass")
-//        val alteredClass = cl.loadClass(runnableClass.name)
-//        val runnable2 = EmptyClassLoader.OBJENISIS.newInstance(alteredClass)
-//        val runMethod = alteredClass.getMethod("run")
-//        runMethod.isAccessible = true
-//        runMethod.invoke(runnable2)
+            val blockState = mockk<BlockState>()
+            val block = mockk<AuraNodeBlock>()
+            every { block.createAuraNode(any(), any(), any()) } returns node
+            every { block.auraNodeType } returns nodeType
 
-        val chunk = ServerAuraNetChunk(updateListener, 64, listOf())
+            val chunk = ServerAuraNetChunk(updateListener, 64, listOf())
 
-        test("Calls updateListener on baseAura change") {
-            chunk.setBaseAura(32)
+            test("Calls updateListener on baseAura change") {
+                chunk.setBaseAura(32)
 
-            verify { updateListener.run() }
+                verify { updateListener.run() }
+            }
+
+            test("Calls updateListener on node add") {
+                chunk.put(node)
+
+                verify { updateListener.run() }
+            }
+
+            test("Calls updateListener on node add during chunk scan") {
+                chunk.updateAuraNodes(world) { callback ->
+                    callback(blockState, block, BlockPos(0, 0, 0))
+                }
+
+                verify { updateListener.run() }
+            }
         }
 
-        test("Calls updateListener on node add") {
-            chunk.put(node)
+        context("Context: With a basic AuraNode") {
+            val node = mockk<AuraNode>()
+            every { node.pos } returns BlockPos(0, 0, 0)
+            every { node.onRemove() } just Runs
 
-            verify { updateListener.run() }
-        }
-    }
+            val chunk = ServerAuraNetChunk({}, 64, listOf(node))
 
-    context("Context: With a basic AuraNode") {
-        val node = mockk<AuraNode>()
-        every { node.pos } returns BlockPos(0, 0, 0)
-        every { node.onRemove() } just Runs
+            test("Calls onRemove on a node being removed") {
+                chunk.remove(BlockPos(0, 0, 0))
 
-        val chunk = ServerAuraNetChunk({}, 64, listOf(node))
-
-        test("Calls onRemove on a node being removed") {
-            chunk.remove(BlockPos(0, 0, 0))
-
-            verify { node.onRemove() }
-        }
-    }
-
-    context("Context: With a basic updateListener and AuraNode") {
-        val updateListener = mockk<Runnable>()
-        every { updateListener.run() } just Runs
-        val node = mockk<AuraNode>()
-        every { node.pos } returns BlockPos(0, 0, 0)
-        every { node.onRemove() } just Runs
-
-        val chunk = ServerAuraNetChunk(updateListener, 64, listOf(node))
-
-        test("Calls updateListener on node remove") {
-            chunk.remove(BlockPos(0, 0, 0))
-
-            verify { updateListener.run() }
-        }
-    }
-
-    context("Context: With a basic SourceAuraNode") {
-        val source = mockk<SourceAuraNode>()
-        every { source.pos } returns BlockPos(0, 0, 0)
-        every { source.getSourceAura() } returns 1
-
-        val chunk = ServerAuraNetChunk({}, 64, listOf(source))
-
-        test("Gives total aura") {
-            chunk.getTotalAura() shouldBe 65
-
-            verify { source.getSourceAura() }
-        }
-    }
-
-    context("Context: With a basic SiphonAuraNode") {
-        val siphon = mockk<SiphonAuraNode>()
-        every { siphon.pos } returns BlockPos(0, 0, 0)
-        every { siphon.recalculateSiphonValue(any(), any()) } just Runs
-
-        val source = mockk<SourceAuraNode>()
-        every { source.pos } returns BlockPos(1, 0, 0)
-        every { source.getSourceAura() } returns 1
-
-        val chunk = ServerAuraNetChunk({}, 64, listOf(siphon))
-
-        test("Recalculates siphon values on base aura change") {
-            chunk.setBaseAura(32)
-
-            verify { siphon.recalculateSiphonValue(32, 1) }
+                verify { node.onRemove() }
+            }
         }
 
-        test("Recalculates siphon values when a source is added") {
-            chunk.put(source)
+        context("Context: With a basic updateListener and AuraNode") {
+            val updateListener = mockk<Runnable>()
+            every { updateListener.run() } just Runs
+            val node = mockk<AuraNode>()
+            every { node.pos } returns BlockPos(0, 0, 0)
+            every { node.onRemove() } just Runs
 
-            verify { siphon.recalculateSiphonValue(65, 1) }
+            val chunk = ServerAuraNetChunk(updateListener, 64, listOf(node))
+
+            test("Calls updateListener on node remove") {
+                chunk.remove(BlockPos(0, 0, 0))
+
+                verify { updateListener.run() }
+            }
         }
-    }
 
-    context("Context: With a basic SourceAuraNode and SiphonAuraNode") {
-        val siphon = mockk<SiphonAuraNode>()
-        every { siphon.pos } returns BlockPos(0, 0, 0)
-        every { siphon.recalculateSiphonValue(any(), any()) } just Runs
+        context("Context: With a basic SourceAuraNode") {
+            val source = mockk<SourceAuraNode>()
+            every { source.pos } returns BlockPos(0, 0, 0)
+            every { source.getSourceAura() } returns 1
 
-        val source = mockk<SourceAuraNode>()
-        every { source.pos } returns BlockPos(1, 0, 0)
-        every { source.getSourceAura() } returns 1
-        every { source.onRemove() } just Runs
+            val chunk = ServerAuraNetChunk({}, 64, listOf(source))
 
-        val chunk = ServerAuraNetChunk({}, 64, listOf(source, siphon))
+            test("Gives total aura") {
+                chunk.getTotalAura() shouldBe 65
 
-        test("Recalculates siphon values when a source is removed") {
-            chunk.remove(BlockPos(1, 0, 0))
+                verify { source.getSourceAura() }
+            }
+        }
 
-            verify { siphon.recalculateSiphonValue(64, 1) }
+        context("Context: With a basic SiphonAuraNode") {
+            val siphon = mockk<SiphonAuraNode>()
+            every { siphon.pos } returns BlockPos(0, 0, 0)
+            every { siphon.recalculateSiphonValue(any(), any()) } just Runs
+
+            val source = mockk<SourceAuraNode>()
+            every { source.pos } returns BlockPos(1, 0, 0)
+            every { source.getSourceAura() } returns 1
+
+            val chunk = ServerAuraNetChunk({}, 64, listOf(siphon))
+
+            test("Recalculates siphon values on base aura change") {
+                chunk.setBaseAura(32)
+
+                verify { siphon.recalculateSiphonValue(32, 1) }
+            }
+
+            test("Recalculates siphon values when a source is added") {
+                chunk.put(source)
+
+                verify { siphon.recalculateSiphonValue(65, 1) }
+            }
+        }
+
+        context("Context: With a basic SourceAuraNode and SiphonAuraNode") {
+            val siphon = mockk<SiphonAuraNode>()
+            every { siphon.pos } returns BlockPos(0, 0, 0)
+            every { siphon.recalculateSiphonValue(any(), any()) } just Runs
+
+            val source = mockk<SourceAuraNode>()
+            every { source.pos } returns BlockPos(1, 0, 0)
+            every { source.getSourceAura() } returns 1
+            every { source.onRemove() } just Runs
+
+            val chunk = ServerAuraNetChunk({}, 64, listOf(source, siphon))
+
+            test("Recalculates siphon values when a source is removed") {
+                chunk.remove(BlockPos(1, 0, 0))
+
+                verify { siphon.recalculateSiphonValue(64, 1) }
+            }
         }
     }
 })

--- a/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
+++ b/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
@@ -1,5 +1,6 @@
 package com.github.hotm.world.auranet.server
 
+import com.github.hotm.EmptyClassLoader
 import com.github.hotm.world.auranet.AuraNode
 import com.github.hotm.world.auranet.SiphonAuraNode
 import com.github.hotm.world.auranet.SourceAuraNode
@@ -7,6 +8,7 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
+import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.math.BlockPos
 
 class ServerAuraNetChunkTests : FunSpec({
@@ -29,6 +31,19 @@ class ServerAuraNetChunkTests : FunSpec({
         val node = mockk<AuraNode>()
         every { node.pos } returns BlockPos(0, 0, 0)
         every { node.onRemove() } just Runs
+
+//        val cl = EmptyClassLoader()
+//        val runnable = Runnable {
+            val world = mockk<ServerWorld>()
+            println("WORLD: $world")
+//        }
+//        val runnableClass = runnable.javaClass
+//        println("Runnable class: $runnableClass")
+//        val alteredClass = cl.loadClass(runnableClass.name)
+//        val runnable2 = EmptyClassLoader.OBJENISIS.newInstance(alteredClass)
+//        val runMethod = alteredClass.getMethod("run")
+//        runMethod.isAccessible = true
+//        runMethod.invoke(runnable2)
 
         val chunk = ServerAuraNetChunk(updateListener, 64, listOf())
 


### PR DESCRIPTION
This adds `ClassLoader`-based mocking to the `ServerAuraNetChunkTests`. This allows for testing of some of the more complicated functions like `updateAuraNodes(...)`.