### PR TITLE
Generate Nectere-side portals in BlockEntities

### DIFF
--- a/src/main/kotlin/com/github/hotm/blockentity/NecterePortalSpawnerBlockEntity.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/NecterePortalSpawnerBlockEntity.kt
@@ -2,16 +2,25 @@ package com.github.hotm.blockentity
 
 import com.github.hotm.blocks.HotMBlocks
 import com.github.hotm.world.gen.HotMPortalGen
+import com.github.hotm.world.gen.feature.HotMStructureFeatures
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtOps
 import net.minecraft.server.world.ServerWorld
+import net.minecraft.util.BlockMirror
+import net.minecraft.util.BlockRotation
+import net.minecraft.util.math.BlockBox
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.ChunkPos
+import net.minecraft.util.math.Direction
 import net.minecraft.world.World
 
+/**
+ * Used for generating Nectere portals on the main server thread where it's ok to access other dimensions so we can make
+ * sure the portals are placed right.
+ */
 class NecterePortalSpawnerBlockEntity(pos: BlockPos, state: BlockState) :
     BlockEntity(HotMBlockEntities.NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY, pos, state) {
     companion object {
@@ -20,7 +29,8 @@ class NecterePortalSpawnerBlockEntity(pos: BlockPos, state: BlockState) :
         }
     }
 
-    var originalBlock = Blocks.AIR.defaultState
+    var originalBlock: BlockState = Blocks.AIR.defaultState
+    var structureCtx: StructureContext? = null
 
     override fun readNbt(tag: NbtCompound) {
         super.readNbt(tag)
@@ -60,7 +70,70 @@ class NecterePortalSpawnerBlockEntity(pos: BlockPos, state: BlockState) :
             }
 
             if (world.structureAccessor.shouldGenerateStructures()) {
-                HotMPortalGen.generateForChunk(world, ChunkPos(pos))
+                val structureCtx = structureCtx
+                if (structureCtx == null) {
+                    // We're generating as a feature, so we just check if there are any portals connected and generate
+                    // them if so.
+                    HotMPortalGen.generateNonNectereSideForChunk(world, ChunkPos(pos))
+                } else {
+                    // We're generating as a structure, so we generate the portal in the place of the structure or
+                    // remove the structure if we couldn't generate the portal.
+                    if (!HotMPortalGen.generateNectereSideForStructure(
+                            world,
+                            structureCtx.boundingBox,
+                            structureCtx::applyXTransform,
+                            structureCtx::applyYTransform,
+                            structureCtx::applyZTransform,
+                            structureCtx.mirror,
+                            structureCtx.rotation
+                        )
+                    ) {
+                        // The portal structure couldn't be generated here so we'll remove the structure piece from the
+                        // structure start.
+                        world.structureAccessor.getStructureAt(
+                            structureCtx.boundingBox.center,
+                            false,
+                            HotMStructureFeatures.NECTERE_PORTAL
+                        ).clearChildren()
+                    }
+                }
+            }
+        }
+    }
+
+    data class StructureContext(
+        val boundingBox: BlockBox,
+        val facing: Direction?,
+        val mirror: BlockMirror,
+        val rotation: BlockRotation
+    ) {
+        fun applyXTransform(x: Int, z: Int): Int {
+            return if (facing == null) {
+                x
+            } else {
+                when (facing) {
+                    Direction.NORTH, Direction.SOUTH -> boundingBox.minX + x
+                    Direction.WEST -> boundingBox.maxX - z
+                    Direction.EAST -> boundingBox.minX + z
+                    else -> x
+                }
+            }
+        }
+
+        fun applyYTransform(y: Int): Int {
+            return if (facing == null) y else y + boundingBox.minY
+        }
+
+        fun applyZTransform(x: Int, z: Int): Int {
+            return if (facing == null) {
+                z
+            } else {
+                when (facing) {
+                    Direction.NORTH -> boundingBox.maxZ - z
+                    Direction.SOUTH -> boundingBox.minZ + z
+                    Direction.WEST, Direction.EAST -> boundingBox.minZ + x
+                    else -> z
+                }
             }
         }
     }

--- a/src/main/kotlin/com/github/hotm/util/WorldUtils.kt
+++ b/src/main/kotlin/com/github/hotm/util/WorldUtils.kt
@@ -2,13 +2,13 @@ package com.github.hotm.util
 
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.world.ChunkRegion
-import net.minecraft.world.WorldAccess
+import net.minecraft.world.WorldView
 
 object WorldUtils {
     /**
      * Converts a WorldAccess into a server world if possible.
      */
-    fun getServerWorld(world: WorldAccess): ServerWorld? {
+    fun getServerWorld(world: WorldView): ServerWorld? {
         return when (world) {
             is ServerWorld -> world
             is ChunkRegion -> world.toServerWorld()

--- a/src/main/kotlin/com/github/hotm/world/HotMLocationConversions.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMLocationConversions.kt
@@ -163,21 +163,24 @@ object HotMLocationConversions {
         }
     }
 
+    fun nectere2NonWorld(nectereWorld: ServerWorld, biomeData: NectereBiomeData): ServerWorld? {
+        val world = nectereWorld.server.getWorld(biomeData.targetWorld)
+        if (world == null) {
+            HotMLog.log.warn("Attempted to get non-existent world for Nectere biome (${biomeData.biome}) with world key: ${biomeData.targetWorld}")
+        }
+        return world
+    }
+
     /* Complex Conversions */
 
     /**
      * Gets the non-Nectere-side world that connects to the current Nectere-side block location.
      */
     fun nectere2NonWorld(nectereWorld: ServerWorld, necterePos: BlockPos): ServerWorld? {
-        val server = nectereWorld.server
         val biomeKey = nectereWorld.getBiomeKey(necterePos)
 
         return HotMBiomeData.ifPortalable(biomeKey) { biomeData ->
-            val world = server.getWorld(biomeData.targetWorld)
-            if (world == null) {
-                HotMLog.log.warn("Attempted to get non-existent world for Nectere biome (${biomeData.biome}) with world key: ${biomeData.targetWorld}")
-            }
-            world
+            nectere2NonWorld(nectereWorld, biomeData)
         }
     }
 

--- a/src/main/kotlin/com/github/hotm/world/HotMLocationConversions.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMLocationConversions.kt
@@ -175,7 +175,7 @@ object HotMLocationConversions {
         return HotMBiomeData.ifPortalable(biomeKey) { biomeData ->
             val world = server.getWorld(biomeData.targetWorld)
             if (world == null) {
-                HotMLog.log.warn("Attempted to get non-existent world for Nectere biome with world key: ${biomeData.targetWorld}")
+                HotMLog.log.warn("Attempted to get non-existent world for Nectere biome (${biomeData.biome}) with world key: ${biomeData.targetWorld}")
             }
             world
         }

--- a/src/main/kotlin/com/github/hotm/world/HotMPortalFinders.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMPortalFinders.kt
@@ -309,9 +309,7 @@ object HotMPortalFinders {
                 val portalPos = HotMLocationConversions.nectere2StartNon(necterePortalPos, nectereBiomeData)!!
 
                 if (portalPos.x shr 4 == currentPos.x && portalPos.z shr 4 == currentPos.z) {
-                    val structurePos = HotMPortalOffsets.portal2StructurePos(portalPos)
-
-                    Stream.of(structurePos)
+                    Stream.of(portalPos)
                 } else {
                     Stream.empty()
                 }

--- a/src/main/kotlin/com/github/hotm/world/HotMPortalGenPositions.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMPortalGenPositions.kt
@@ -22,7 +22,7 @@ object HotMPortalGenPositions {
     /**
      * Gets the location of the portal spawner block entity within a chunk.
      */
-    fun getPortalSpawnerPos(pos: ChunkPos): BlockPos = BlockPos(pos.startX, 0, pos.startZ)
+    fun getPortalSpawnerPos(pos: ChunkPos): BlockPos = BlockPos(pos.startX, 1, pos.startZ)
 
     /**
      * Scans the world at the given x and z coordinates for valid biomes and surfaces.

--- a/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
@@ -266,7 +266,7 @@ object HotMPortalGen {
         addBlock(wStairs, 4, 3, 2)
 
         addBlock(uPortal, HotMPortalOffsets.transform2PortalPos(applyXTransform, applyYTransform, applyZTransform))
-        addBlock(dPortal, HotMPortalOffsets.transform2PortalPos(applyXTransform, applyYTransform, applyZTransform))
+        addBlock(dPortal, HotMPortalOffsets.transform2PortalPos(applyXTransform, applyYTransform, applyZTransform).up())
 
         fill(0, 1, 1, 4, 2, 1)
         fill(0, 1, 3, 4, 2, 3)

--- a/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
@@ -94,8 +94,8 @@ object HotMPortalGen {
                 world.registryKey,
                 pos,
                 nectereWorld
-            ).forEach { structureXZ ->
-                HotMPortalGenPositions.findValidNonNecterePortalPos(world, structureXZ.x, structureXZ.z)
+            ).forEach { portalXZ ->
+                HotMPortalGenPositions.findValidNonNecterePortalPos(world, portalXZ.x, portalXZ.z)
                     ?.let { portalPos ->
                         // Make sure the portal is in an enabled biome and not in a Nectere biome.
                         val biome = world.getBiomeKey(portalPos).orElse(null)

--- a/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/HotMPortalGen.kt
@@ -96,15 +96,15 @@ object HotMPortalGen {
                 nectereWorld
             ).forEach { structureXZ ->
                 HotMPortalGenPositions.findValidNonNecterePortalPos(world, structureXZ.x, structureXZ.z)
-                    ?.let { structurePos ->
+                    ?.let { portalPos ->
                         // Make sure the portal is in an enabled biome and not in a Nectere biome.
-                        val portalPos = HotMPortalOffsets.structure2PortalPos(structurePos)
                         val biome = world.getBiomeKey(portalPos).orElse(null)
 
                         if (biome != null
                             && !HotMBiomeData.getDataById().containsKey(biome)
                             && HotMPortalFinders.findNecterePortal(world, listOf(portalPos)) == null
                         ) {
+                            val structurePos = HotMPortalOffsets.portal2StructurePos(portalPos)
                             generate(world, structurePos)
                         }
                     }


### PR DESCRIPTION
Previously only Non-Nectere side portals were generated using block entities because Non-Nectere side portal generation requires complex logic involving accessing the Nectere dimension. Accessing the Nectere dimension directly in world-gen would have caused threading dead-locks.

The mechanism for determining whether to generate a Nectere portal on the Nectere side is not as complex, but does still require accessing Non-Nectere dimensions to make sure the portal is not generating in a location connected to denied Non-Nectere biome. This biome access required a peculiar dance to prevent the threading dead-lock that comes from accessing other dimensions while performing world-gen.

This PR moves the Nectere side portal generation to the BlockEntity-based system as well.