### PR TITLE
Remove Static Initializers

### DIFF
--- a/src/main/java/com/github/hotm/mixinapi/DimensionAdditions.java
+++ b/src/main/java/com/github/hotm/mixinapi/DimensionAdditions.java
@@ -45,8 +45,6 @@ public class DimensionAdditions {
             long seed,
             SimpleRegistry<DimensionOptions> optionsRegistry,
             String message) {
-        // Make sure dimensions are registered in time.
-        HotMDimensions.INSTANCE.register();
 
         HotMLog.INSTANCE.getLog().info("HotM Adding Dimensions to " + message + ":");
         for (DimensionAddition addition : ADDITIONS) {

--- a/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
+++ b/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
@@ -11,6 +11,7 @@ import com.github.hotm.world.HotMDimensions
 import com.github.hotm.world.HotMTeleporters
 import com.github.hotm.world.biome.HotMBiomes
 import com.github.hotm.world.gen.feature.HotMFeatures
+import com.github.hotm.world.gen.surfacebuilder.HotMSurfaceBuilders
 
 /**
  * Initializer for Heart of the Machine mod.
@@ -23,6 +24,7 @@ fun init() {
     HotMItems.register()
     HotMBlockEntities.register()
     HotMFeatures.register()
+    HotMSurfaceBuilders.register()
     HotMBiomes.register()
     HotMDimensions.register()
     HotMTeleporters.register()

--- a/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
+++ b/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
@@ -4,6 +4,7 @@ import com.github.hotm.blockentity.HotMBlockEntities
 import com.github.hotm.blocks.HotMBlocks
 import com.github.hotm.command.HotMCommands
 import com.github.hotm.items.HotMItems
+import com.github.hotm.misc.HotMBlockTags
 import com.github.hotm.misc.HotMFuels
 import com.github.hotm.world.HotMDimensions
 import com.github.hotm.world.HotMTeleporters
@@ -16,6 +17,7 @@ import com.github.hotm.world.gen.feature.HotMFeatures
 @Suppress("unused")
 fun init() {
     HotMBlocks.register()
+    HotMBlockTags.register()
     HotMItems.register()
     HotMBlockEntities.register()
     HotMFeatures.register()

--- a/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
+++ b/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
@@ -6,6 +6,7 @@ import com.github.hotm.command.HotMCommands
 import com.github.hotm.items.HotMItems
 import com.github.hotm.misc.HotMBlockTags
 import com.github.hotm.misc.HotMFuels
+import com.github.hotm.misc.HotMRegistries
 import com.github.hotm.world.HotMDimensions
 import com.github.hotm.world.HotMTeleporters
 import com.github.hotm.world.biome.HotMBiomes
@@ -16,6 +17,7 @@ import com.github.hotm.world.gen.feature.HotMFeatures
  */
 @Suppress("unused")
 fun init() {
+    HotMRegistries.register()
     HotMBlocks.register()
     HotMBlockTags.register()
     HotMItems.register()

--- a/src/main/kotlin/com/github/hotm/blockentity/HotMBlockEntities.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/HotMBlockEntities.kt
@@ -1,7 +1,7 @@
 package com.github.hotm.blockentity
 
-import com.github.hotm.blocks.HotMBlocks
 import com.github.hotm.HotMConstants
+import com.github.hotm.blocks.HotMBlocks
 import com.google.common.collect.Sets
 import net.minecraft.block.Block
 import net.minecraft.block.BlockState
@@ -11,10 +11,12 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.registry.Registry
 
 object HotMBlockEntities {
-    val NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY =
-        newBlockEntityType(::NecterePortalSpawnerBlockEntity, HotMBlocks.NECTERE_PORTAL_SPAWNER)
+    lateinit var NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY: BlockEntityType<NecterePortalSpawnerBlockEntity>
 
     fun register() {
+        NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY =
+            newBlockEntityType(::NecterePortalSpawnerBlockEntity, HotMBlocks.NECTERE_PORTAL_SPAWNER)
+
         register(NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY, "nectere_portal_spawner")
     }
 

--- a/src/main/kotlin/com/github/hotm/blockentity/HotMBlockEntities.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/HotMBlockEntities.kt
@@ -12,6 +12,7 @@ import net.minecraft.util.registry.Registry
 
 object HotMBlockEntities {
     lateinit var NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY: BlockEntityType<NecterePortalSpawnerBlockEntity>
+        private set
 
     fun register() {
         NECTERE_PORTAL_SPAWNER_BLOCK_ENTITY =

--- a/src/main/kotlin/com/github/hotm/blocks/HotMBlocks.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/HotMBlocks.kt
@@ -1,10 +1,10 @@
 package com.github.hotm.blocks
 
 import com.github.hotm.HotMConstants
-import com.github.hotm.items.HotMItems.HOTM_BUILDING_ITEM_SETTINGS
-import com.github.hotm.items.HotMItems.HOTM_MATERIAL_ITEM_SETTINGS
 import com.github.hotm.blocks.spore.StandardPlasseinSporeGenerator
 import com.github.hotm.items.BracingItem
+import com.github.hotm.items.HotMItems.HOTM_BUILDING_ITEM_SETTINGS
+import com.github.hotm.items.HotMItems.HOTM_MATERIAL_ITEM_SETTINGS
 import com.github.hotm.items.ScaffoldingItem
 import com.github.hotm.mixinapi.BlockCreators
 import net.fabricmc.fabric.api.`object`.builder.v1.block.FabricBlockSettings
@@ -26,161 +26,196 @@ object HotMBlocks {
     /*
      * Block Settings.
      */
-    private val BRACING_SETTINGS =
+    private val BRACING_SETTINGS by lazy {
         FabricBlockSettings.of(Material.METAL, MapColor.GRAY).requiresTool().strength(1.0f, 15.0f)
             .sounds(BlockSoundGroup.METAL).nonOpaque()
-    private val CYAN_CRYSTAL_BLOCK_SETTINGS =
+    }
+    private val CYAN_CRYSTAL_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.GLASS, MapColor.CYAN).requiresTool().breakByTool(FabricToolTags.PICKAXES)
             .strength(2.0f, 5.0f).sounds(BlockSoundGroup.GLASS).luminance(15)
-    private val CYAN_LAMP_BLOCK_SETTINGS =
+    }
+    private val CYAN_LAMP_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.STONE, MapColor.CYAN).requiresTool().strength(2.0f, 5.0f)
             .sounds(BlockSoundGroup.STONE).luminance(15)
-    private val CYAN_MACHINE_CASING_LAMP_BLOCK_SETTINGS =
+    }
+    private val CYAN_MACHINE_CASING_LAMP_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.METAL, MapColor.CYAN).requiresTool().strength(2.0f, 5.0f)
             .sounds(BlockSoundGroup.METAL).luminance(15)
-    private val MACHINE_CASING_SETTINGS =
+    }
+    private val MACHINE_CASING_SETTINGS by lazy {
         FabricBlockSettings.of(Material.METAL, MapColor.BLACK).requiresTool().strength(3.0f, 10.0f)
             .sounds(BlockSoundGroup.METAL)
-    private val MAGENTA_CRYSTAL_BLOCK_SETTINGS =
+    }
+    private val MAGENTA_CRYSTAL_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.GLASS, MapColor.MAGENTA).requiresTool().breakByTool(FabricToolTags.PICKAXES)
             .strength(2.0f, 5.0f).sounds(BlockSoundGroup.GLASS).luminance(15)
-    private val MAGENTA_LAMP_BLOCK_SETTINGS =
+    }
+    private val MAGENTA_LAMP_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.STONE, MapColor.MAGENTA).requiresTool().strength(2.0f, 5.0f)
             .sounds(BlockSoundGroup.STONE).luminance(15)
-    private val MAGENTA_MACHINE_CASING_LAMP_BLOCK_SETTINGS =
+    }
+    private val MAGENTA_MACHINE_CASING_LAMP_BLOCK_SETTINGS by lazy {
         FabricBlockSettings.of(Material.METAL, MapColor.MAGENTA).requiresTool().strength(2.0f, 5.0f)
             .sounds(BlockSoundGroup.METAL).luminance(15)
-    private val OBELISK_PART_SETTINGS =
+    }
+    private val OBELISK_PART_SETTINGS by lazy {
         FabricBlockSettings.of(Material.METAL, MapColor.DARK_AQUA).requiresTool().strength(3.0f, 10.0f)
             .sounds(BlockSoundGroup.STONE)
-    private val PLASSEIN_LOG_SETTINGS =
+    }
+    private val PLASSEIN_LOG_SETTINGS by lazy {
         FabricBlockSettings.of(Material.WOOD, MapColor.BLUE).breakByTool(FabricToolTags.AXES).strength(1.0f, 10.0f)
             .sounds(BlockSoundGroup.WOOD)
-    private val THINKING_STONE_SETTINGS =
+    }
+    private val THINKING_STONE_SETTINGS by lazy {
         FabricBlockSettings.of(Material.STONE, MapColor.BLACK).requiresTool().strength(3.0f, 10.0f)
             .sounds(BlockSoundGroup.STONE)
+    }
 
 
     /*
      * Leyline blocks.
      */
     private val LEYLINE_BLOCKS = hashSetOf<Block>()
-    val MACHINE_CASING_LEYLINE = addLeyline(Block(MACHINE_CASING_SETTINGS))
-    val PLASSEIN_GRASS_LEYLINE = addLeyline(Block(MACHINE_CASING_SETTINGS))
-    val PLASSEIN_LOG_LEYLINE = addLeyline(PillarBlock(PLASSEIN_LOG_SETTINGS))
-    val RUSTED_MACHINE_CASING_LEYLINE = addLeyline(Block(MACHINE_CASING_SETTINGS))
-    val SMOOTH_THINKING_STONE_LEYLINE = addLeyline(Block(THINKING_STONE_SETTINGS))
-    val SURFACE_MACHINE_CASING_LEYLINE = addLeyline(Block(MACHINE_CASING_SETTINGS))
-    val THINKING_STONE_LEYLINE = addLeyline(Block(THINKING_STONE_SETTINGS))
+    val MACHINE_CASING_LEYLINE by lazy { addLeyline(Block(MACHINE_CASING_SETTINGS)) }
+    val PLASSEIN_GRASS_LEYLINE by lazy { addLeyline(Block(MACHINE_CASING_SETTINGS)) }
+    val PLASSEIN_LOG_LEYLINE by lazy { addLeyline(PillarBlock(PLASSEIN_LOG_SETTINGS)) }
+    val RUSTED_MACHINE_CASING_LEYLINE by lazy { addLeyline(Block(MACHINE_CASING_SETTINGS)) }
+    val SMOOTH_THINKING_STONE_LEYLINE by lazy { addLeyline(Block(THINKING_STONE_SETTINGS)) }
+    val SURFACE_MACHINE_CASING_LEYLINE by lazy { addLeyline(Block(MACHINE_CASING_SETTINGS)) }
+    val THINKING_STONE_LEYLINE by lazy { addLeyline(Block(THINKING_STONE_SETTINGS)) }
 
     /*
      * Crystals & Lamps.
      */
-    val CYAN_CRYSTAL = Block(CYAN_CRYSTAL_BLOCK_SETTINGS)
-    val CYAN_CRYSTAL_LAMP = Block(CYAN_LAMP_BLOCK_SETTINGS)
-    val CYAN_MACHINE_CASING_LAMP = Block(CYAN_MACHINE_CASING_LAMP_BLOCK_SETTINGS)
-    val CYAN_THINKING_STONE_LAMP = Block(CYAN_LAMP_BLOCK_SETTINGS)
-    val MAGENTA_CRYSTAL = Block(MAGENTA_CRYSTAL_BLOCK_SETTINGS)
-    val MAGENTA_CRYSTAL_LAMP = Block(MAGENTA_LAMP_BLOCK_SETTINGS)
-    val MAGENTA_MACHINE_CASING_LAMP = Block(MAGENTA_MACHINE_CASING_LAMP_BLOCK_SETTINGS)
-    val MAGENTA_THINKING_STONE_LAMP = Block(MAGENTA_LAMP_BLOCK_SETTINGS)
+    val CYAN_CRYSTAL by lazy { Block(CYAN_CRYSTAL_BLOCK_SETTINGS) }
+    val CYAN_CRYSTAL_LAMP by lazy { Block(CYAN_LAMP_BLOCK_SETTINGS) }
+    val CYAN_MACHINE_CASING_LAMP by lazy { Block(CYAN_MACHINE_CASING_LAMP_BLOCK_SETTINGS) }
+    val CYAN_THINKING_STONE_LAMP by lazy { Block(CYAN_LAMP_BLOCK_SETTINGS) }
+    val MAGENTA_CRYSTAL by lazy { Block(MAGENTA_CRYSTAL_BLOCK_SETTINGS) }
+    val MAGENTA_CRYSTAL_LAMP by lazy { Block(MAGENTA_LAMP_BLOCK_SETTINGS) }
+    val MAGENTA_MACHINE_CASING_LAMP by lazy { Block(MAGENTA_MACHINE_CASING_LAMP_BLOCK_SETTINGS) }
+    val MAGENTA_THINKING_STONE_LAMP by lazy { Block(MAGENTA_LAMP_BLOCK_SETTINGS) }
 
     /*
      * Obelisk parts.
      */
-    val GLOWY_OBELISK_PART = PillarBlock(OBELISK_PART_SETTINGS)
-    val OBELISK_PART = PillarBlock(OBELISK_PART_SETTINGS)
-    val NECTERE_PORTAL = NecterePortalBlock(
-        FabricBlockSettings.of(Material.PORTAL, MapColor.CYAN).noCollision().strength(-1.0f)
-            .sounds(BlockSoundGroup.GLASS).nonOpaque().luminance(12)
-    )
-    val NECTERE_PORTAL_SPAWNER =
+    val GLOWY_OBELISK_PART by lazy { PillarBlock(OBELISK_PART_SETTINGS) }
+    val OBELISK_PART by lazy { PillarBlock(OBELISK_PART_SETTINGS) }
+    val NECTERE_PORTAL by lazy {
+        NecterePortalBlock(
+            FabricBlockSettings.of(Material.PORTAL, MapColor.CYAN).noCollision().strength(-1.0f)
+                .sounds(BlockSoundGroup.GLASS).nonOpaque().luminance(12)
+        )
+    }
+    val NECTERE_PORTAL_SPAWNER by lazy {
         NecterePortalSpawnerBlock(FabricBlockSettings.of(Material.STONE, MapColor.DARK_AQUA).strength(-1.0f))
+    }
 
     /*
      * Machine Casing Blocks.
      */
-    val MACHINE_CASING = LeylineableBlock(MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS)
-    val MACHINE_CASING_BRICKS = Block(MACHINE_CASING_SETTINGS)
-    val METAL_MACHINE_CASING = Block(MACHINE_CASING_SETTINGS)
-    val PLASSEIN_MACHINE_CASING = Block(MACHINE_CASING_SETTINGS)
-    val RUSTED_MACHINE_CASING = LeylineableBlock(RUSTED_MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS)
-    val SURFACE_MACHINE_CASING = LeylineableBlock(SURFACE_MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS)
-    val TEST_MACHINE_CASING = Block(MACHINE_CASING_SETTINGS)
-    val MACHINE_CASING_STAIRS = BlockCreators.createStairsBlock(MACHINE_CASING.defaultState, MACHINE_CASING_SETTINGS)
-    val MACHINE_CASING_BRICK_STAIRS =
+    val MACHINE_CASING by lazy { LeylineableBlock(MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS) }
+    val MACHINE_CASING_BRICKS by lazy { Block(MACHINE_CASING_SETTINGS) }
+    val METAL_MACHINE_CASING by lazy { Block(MACHINE_CASING_SETTINGS) }
+    val PLASSEIN_MACHINE_CASING by lazy { Block(MACHINE_CASING_SETTINGS) }
+    val RUSTED_MACHINE_CASING by lazy { LeylineableBlock(RUSTED_MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS) }
+    val SURFACE_MACHINE_CASING by lazy { LeylineableBlock(SURFACE_MACHINE_CASING_LEYLINE, MACHINE_CASING_SETTINGS) }
+    val TEST_MACHINE_CASING by lazy { Block(MACHINE_CASING_SETTINGS) }
+    val MACHINE_CASING_STAIRS by lazy {
+        BlockCreators.createStairsBlock(MACHINE_CASING.defaultState, MACHINE_CASING_SETTINGS)
+    }
+    val MACHINE_CASING_BRICK_STAIRS by lazy {
         BlockCreators.createStairsBlock(MACHINE_CASING_BRICKS.defaultState, MACHINE_CASING_SETTINGS)
-    val MACHINE_CASING_SLAB = SlabBlock(MACHINE_CASING_SETTINGS)
-    val MACHINE_CASING_BRICK_SLAB = SlabBlock(MACHINE_CASING_SETTINGS)
+    }
+    val MACHINE_CASING_SLAB by lazy { SlabBlock(MACHINE_CASING_SETTINGS) }
+    val MACHINE_CASING_BRICK_SLAB by lazy { SlabBlock(MACHINE_CASING_SETTINGS) }
 
     /*
      * Bracing Blocks.
      */
-    val METAL_BRACING = BracingBlock(BRACING_SETTINGS)
-    val PLASSEIN_BRACING = BracingBlock(BRACING_SETTINGS)
+    val METAL_BRACING by lazy { BracingBlock(BRACING_SETTINGS) }
+    val PLASSEIN_BRACING by lazy { BracingBlock(BRACING_SETTINGS) }
 
     /*
      * Plassein Blocks.
      */
-    val PLASSEIN_BLOOM = Block(
-        FabricBlockSettings.of(Material.LEAVES, MapColor.BLUE).strength(1.0f, 10.0f).sounds(BlockSoundGroup.WOOL)
-            .nonOpaque().allowsSpawning(HotMBlocks::never)
-    )
-    val PLASSEIN_FUEL_BLOCK =
-        Block(FabricBlockSettings.of(Material.STONE, MapColor.BLACK).requiresTool().strength(5.0F, 6.0F))
-    val PLASSEIN_GRASS = LeylineableBlock(PLASSEIN_GRASS_LEYLINE, MACHINE_CASING_SETTINGS)
-    val PLASSEIN_LEAVES = PlasseinLeavesBlock(
-        FabricBlockSettings.of(Material.LEAVES, MapColor.CYAN).strength(0.2f).ticksRandomly()
-            .sounds(BlockSoundGroup.GRASS).nonOpaque().allowsSpawning(HotMBlocks::never).suffocates(HotMBlocks::never)
-            .blockVision(HotMBlocks::never)
-    )
-    val PLASSEIN_LOG = LeylineablePillarBlock(PLASSEIN_LOG_LEYLINE, PLASSEIN_LOG_SETTINGS)
-    val PLASSEIN_PLANKS = Block(PLASSEIN_LOG_SETTINGS)
-    val PLASSEIN_SCAFFOLDING = ScaffoldingBlock(
-        FabricBlockSettings.of(Material.DECORATION, MapColor.BLUE).noCollision().sounds(BlockSoundGroup.SCAFFOLDING)
-            .dynamicBounds()
-    )
-    val PLASSEIN_SPORE = PlasseinSporeBlock(
-        StandardPlasseinSporeGenerator,
-        FabricBlockSettings.of(Material.PLANT, MapColor.BLUE).noCollision().ticksRandomly().breakInstantly()
-            .sounds(BlockSoundGroup.GRASS)
-    )
-    val PLASSEIN_STEM = PillarBlock(PLASSEIN_LOG_SETTINGS)
+    val PLASSEIN_BLOOM by lazy {
+        Block(
+            FabricBlockSettings.of(Material.LEAVES, MapColor.BLUE).strength(1.0f, 10.0f).sounds(BlockSoundGroup.WOOL)
+                .nonOpaque().allowsSpawning(HotMBlocks::never)
+        )
+    }
+    val PLASSEIN_FUEL_BLOCK by lazy {
+        Block(
+            FabricBlockSettings.of(Material.STONE, MapColor.BLACK).requiresTool().strength(5.0F, 6.0F)
+        )
+    }
+    val PLASSEIN_GRASS by lazy { LeylineableBlock(PLASSEIN_GRASS_LEYLINE, MACHINE_CASING_SETTINGS) }
+    val PLASSEIN_LEAVES by lazy {
+        PlasseinLeavesBlock(
+            FabricBlockSettings.of(Material.LEAVES, MapColor.CYAN).strength(0.2f).ticksRandomly()
+                .sounds(BlockSoundGroup.GRASS).nonOpaque().allowsSpawning(HotMBlocks::never)
+                .suffocates(HotMBlocks::never).blockVision(HotMBlocks::never)
+        )
+    }
+    val PLASSEIN_LOG by lazy { LeylineablePillarBlock(PLASSEIN_LOG_LEYLINE, PLASSEIN_LOG_SETTINGS) }
+    val PLASSEIN_PLANKS by lazy { Block(PLASSEIN_LOG_SETTINGS) }
+    val PLASSEIN_SCAFFOLDING by lazy {
+        ScaffoldingBlock(
+            FabricBlockSettings.of(Material.DECORATION, MapColor.BLUE).noCollision().sounds(BlockSoundGroup.SCAFFOLDING)
+                .dynamicBounds()
+        )
+    }
+    val PLASSEIN_SPORE by lazy {
+        PlasseinSporeBlock(
+            StandardPlasseinSporeGenerator,
+            FabricBlockSettings.of(Material.PLANT, MapColor.BLUE).noCollision().ticksRandomly().breakInstantly()
+                .sounds(BlockSoundGroup.GRASS)
+        )
+    }
+    val PLASSEIN_STEM by lazy { PillarBlock(PLASSEIN_LOG_SETTINGS) }
 
     /*
      * Thinking Stone Blocks.
      */
-    val SMOOTH_THINKING_STONE = LeylineableBlock(SMOOTH_THINKING_STONE_LEYLINE, THINKING_STONE_SETTINGS)
-    val THINKING_STONE = LeylineableBlock(THINKING_STONE_LEYLINE, THINKING_STONE_SETTINGS)
-    val THINKING_STONE_BRICKS = Block(THINKING_STONE_SETTINGS)
-    val THINKING_STONE_TILES = Block(THINKING_STONE_SETTINGS)
-    val SMOOTH_THINKING_STONE_STAIRS =
+    val SMOOTH_THINKING_STONE by lazy { LeylineableBlock(SMOOTH_THINKING_STONE_LEYLINE, THINKING_STONE_SETTINGS) }
+    val THINKING_STONE by lazy { LeylineableBlock(THINKING_STONE_LEYLINE, THINKING_STONE_SETTINGS) }
+    val THINKING_STONE_BRICKS by lazy { Block(THINKING_STONE_SETTINGS) }
+    val THINKING_STONE_TILES by lazy { Block(THINKING_STONE_SETTINGS) }
+    val SMOOTH_THINKING_STONE_STAIRS by lazy {
         BlockCreators.createStairsBlock(SMOOTH_THINKING_STONE.defaultState, THINKING_STONE_SETTINGS)
-    val THINKING_STONE_STAIRS = BlockCreators.createStairsBlock(THINKING_STONE.defaultState, THINKING_STONE_SETTINGS)
-    val THINKING_STONE_BRICK_STAIRS =
+    }
+    val THINKING_STONE_STAIRS by lazy {
+        BlockCreators.createStairsBlock(THINKING_STONE.defaultState, THINKING_STONE_SETTINGS)
+    }
+    val THINKING_STONE_BRICK_STAIRS by lazy {
         BlockCreators.createStairsBlock(THINKING_STONE_BRICKS.defaultState, THINKING_STONE_SETTINGS)
-    val THINKING_STONE_TILE_STAIRS =
+    }
+    val THINKING_STONE_TILE_STAIRS by lazy {
         BlockCreators.createStairsBlock(THINKING_STONE_TILES.defaultState, THINKING_STONE_SETTINGS)
-    val SMOOTH_THINKING_STONE_SLAB = SlabBlock(THINKING_STONE_SETTINGS)
-    val THINKING_STONE_SLAB = SlabBlock(THINKING_STONE_SETTINGS)
-    val THINKING_STONE_BRICK_SLAB = SlabBlock(THINKING_STONE_SETTINGS)
-    val THINKING_STONE_TILE_SLAB = SlabBlock(THINKING_STONE_SETTINGS)
+    }
+    val SMOOTH_THINKING_STONE_SLAB by lazy { SlabBlock(THINKING_STONE_SETTINGS) }
+    val THINKING_STONE_SLAB by lazy { SlabBlock(THINKING_STONE_SETTINGS) }
+    val THINKING_STONE_BRICK_SLAB by lazy { SlabBlock(THINKING_STONE_SETTINGS) }
+    val THINKING_STONE_TILE_SLAB by lazy { SlabBlock(THINKING_STONE_SETTINGS) }
 
     /*
      * Sand blocks.
      */
-    private val SAND_SETTINGS =
+    private val SAND_SETTINGS by lazy {
         FabricBlockSettings.of(Material.AGGREGATE, MapColor.DEEPSLATE_GRAY).strength(0.5F).sounds(BlockSoundGroup.SAND)
-    val NULL_SAND = SandBlock(0x29261d, SAND_SETTINGS)
+    }
+    val NULL_SAND by lazy { SandBlock(0x29261d, SAND_SETTINGS) }
 
     /*
      * Thinking glass blocks.
      */
-    private val GLASS_SETTINGS =
+    private val GLASS_SETTINGS by lazy {
         FabricBlockSettings.of(Material.GLASS, MapColor.BLACK).strength(0.5f, 10.0f).sounds(BlockSoundGroup.GLASS)
             .nonOpaque().allowsSpawning(HotMBlocks::never).solidBlock(HotMBlocks::never).suffocates(HotMBlocks::never)
             .blockVision(HotMBlocks::never)
-    val THINKING_GLASS = GlassBlock(GLASS_SETTINGS)
+    }
+    val THINKING_GLASS by lazy { GlassBlock(GLASS_SETTINGS) }
 
     /**
      * Register all Heart of the Machine blocks...

--- a/src/main/kotlin/com/github/hotm/client/HeartOfTheMachineModClient.kt
+++ b/src/main/kotlin/com/github/hotm/client/HeartOfTheMachineModClient.kt
@@ -7,6 +7,7 @@ import com.github.hotm.client.blockmodel.HotMBlockModels
  */
 @Suppress("unused")
 fun init() {
+    HotMClientRegistries.register()
     HotMBlocksClient.register()
     HotMBlockModels.register()
     HotMColorProviders.register()

--- a/src/main/kotlin/com/github/hotm/client/HotMClientRegistries.kt
+++ b/src/main/kotlin/com/github/hotm/client/HotMClientRegistries.kt
@@ -19,25 +19,35 @@ object HotMClientRegistries {
 
     // keys
 
-    val BLOCK_MODEL_KEY = RegistryKey.ofRegistry<Codec<out UnbakedModel>>(BLOCK_MODEL_IDENTIFIER)
-    val BLOCK_MODEL_LAYER_KEY = RegistryKey.ofRegistry<Codec<out UnbakedModelLayer>>(BLOCK_MODEL_LAYER_IDENTIFIER)
-    val BLOCK_MODEL_CONNECTOR_KEY = RegistryKey.ofRegistry<ModelConnector>(BLOCK_MODEL_CONNECTOR_IDENTIFIER)
+    val BLOCK_MODEL_KEY by lazy { RegistryKey.ofRegistry<Codec<out UnbakedModel>>(BLOCK_MODEL_IDENTIFIER) }
+    val BLOCK_MODEL_LAYER_KEY by lazy {
+        RegistryKey.ofRegistry<Codec<out UnbakedModelLayer>>(
+            BLOCK_MODEL_LAYER_IDENTIFIER
+        )
+    }
+    val BLOCK_MODEL_CONNECTOR_KEY by lazy { RegistryKey.ofRegistry<ModelConnector>(BLOCK_MODEL_CONNECTOR_IDENTIFIER) }
 
     // registries
 
-    val BLOCK_MODEL: Registry<Codec<out UnbakedModel>> = Registry.register(
-        Registry.REGISTRIES as Registry<in Registry<*>>,
-        BLOCK_MODEL_IDENTIFIER,
-        SimpleRegistry(BLOCK_MODEL_KEY, Lifecycle.experimental())
-    )
-    val BLOCK_MODEL_LAYER: Registry<Codec<out UnbakedModelLayer>> = Registry.register(
-        Registry.REGISTRIES as Registry<in Registry<*>>,
-        BLOCK_MODEL_LAYER_IDENTIFIER,
-        SimpleRegistry(BLOCK_MODEL_LAYER_KEY, Lifecycle.experimental())
-    )
-    val BLOCK_MODEL_CONNECTOR: Registry<ModelConnector> = Registry.register(
-        Registry.REGISTRIES as Registry<in Registry<*>>,
-        BLOCK_MODEL_CONNECTOR_IDENTIFIER,
-        SimpleRegistry(BLOCK_MODEL_CONNECTOR_KEY, Lifecycle.experimental())
-    )
+    lateinit var BLOCK_MODEL: Registry<Codec<out UnbakedModel>>
+    lateinit var BLOCK_MODEL_LAYER: Registry<Codec<out UnbakedModelLayer>>
+    lateinit var BLOCK_MODEL_CONNECTOR: Registry<ModelConnector>
+
+    fun register() {
+        BLOCK_MODEL = Registry.register(
+            Registry.REGISTRIES as Registry<in Registry<*>>,
+            BLOCK_MODEL_IDENTIFIER,
+            SimpleRegistry(BLOCK_MODEL_KEY, Lifecycle.experimental())
+        )
+        BLOCK_MODEL_LAYER = Registry.register(
+            Registry.REGISTRIES as Registry<in Registry<*>>,
+            BLOCK_MODEL_LAYER_IDENTIFIER,
+            SimpleRegistry(BLOCK_MODEL_LAYER_KEY, Lifecycle.experimental())
+        )
+        BLOCK_MODEL_CONNECTOR = Registry.register(
+            Registry.REGISTRIES as Registry<in Registry<*>>,
+            BLOCK_MODEL_CONNECTOR_IDENTIFIER,
+            SimpleRegistry(BLOCK_MODEL_CONNECTOR_KEY, Lifecycle.experimental())
+        )
+    }
 }

--- a/src/main/kotlin/com/github/hotm/client/HotMClientRegistries.kt
+++ b/src/main/kotlin/com/github/hotm/client/HotMClientRegistries.kt
@@ -30,8 +30,11 @@ object HotMClientRegistries {
     // registries
 
     lateinit var BLOCK_MODEL: Registry<Codec<out UnbakedModel>>
+        private set
     lateinit var BLOCK_MODEL_LAYER: Registry<Codec<out UnbakedModelLayer>>
+        private set
     lateinit var BLOCK_MODEL_CONNECTOR: Registry<ModelConnector>
+        private set
 
     fun register() {
         BLOCK_MODEL = Registry.register(

--- a/src/main/kotlin/com/github/hotm/items/HotMItems.kt
+++ b/src/main/kotlin/com/github/hotm/items/HotMItems.kt
@@ -8,17 +8,15 @@ import net.minecraft.item.ItemStack
 import net.minecraft.util.registry.Registry
 
 object HotMItems {
-    val HOTM_BUILDING_ITEM_GROUP =
-        FabricItemGroupBuilder.build(HotMConstants.identifier("building"), HotMItems::buildingGroupItem)
-    val HOTM_MATERIAL_ITEM_GROUP =
-        FabricItemGroupBuilder.build(HotMConstants.identifier("materials"), HotMItems::materialGroupItem)
+    val HOTM_BUILDING_ITEM_GROUP by lazy { FabricItemGroupBuilder.build(HotMConstants.identifier("building"), HotMItems::buildingGroupItem) }
+    val HOTM_MATERIAL_ITEM_GROUP by lazy { FabricItemGroupBuilder.build(HotMConstants.identifier("materials"), HotMItems::materialGroupItem) }
 
-    val HOTM_BUILDING_ITEM_SETTINGS: Item.Settings = Item.Settings().group(HOTM_BUILDING_ITEM_GROUP)
-    val HOTM_MATERIAL_ITEM_SETTINGS: Item.Settings = Item.Settings().group(HOTM_MATERIAL_ITEM_GROUP)
+    val HOTM_BUILDING_ITEM_SETTINGS: Item.Settings by lazy { Item.Settings().group(HOTM_BUILDING_ITEM_GROUP) }
+    val HOTM_MATERIAL_ITEM_SETTINGS: Item.Settings by lazy { Item.Settings().group(HOTM_MATERIAL_ITEM_GROUP) }
 
-    val CYAN_CRYSTAL_SHARD = Item(HOTM_MATERIAL_ITEM_SETTINGS)
-    val MAGENTA_CRYSTAL_SHARD = Item(HOTM_MATERIAL_ITEM_SETTINGS)
-    val PLASSEIN_FUEL_CHUNK = Item(HOTM_MATERIAL_ITEM_SETTINGS)
+    val CYAN_CRYSTAL_SHARD by lazy { Item(HOTM_MATERIAL_ITEM_SETTINGS) }
+    val MAGENTA_CRYSTAL_SHARD by lazy { Item(HOTM_MATERIAL_ITEM_SETTINGS) }
+    val PLASSEIN_FUEL_CHUNK by lazy { Item(HOTM_MATERIAL_ITEM_SETTINGS) }
 
     fun register() {
         register(CYAN_CRYSTAL_SHARD, "cyan_crystal_shard")

--- a/src/main/kotlin/com/github/hotm/misc/HotMBlockTags.kt
+++ b/src/main/kotlin/com/github/hotm/misc/HotMBlockTags.kt
@@ -2,10 +2,23 @@ package com.github.hotm.misc
 
 import com.github.hotm.HotMConstants
 import net.fabricmc.fabric.api.tag.TagRegistry
+import net.minecraft.block.Block
+import net.minecraft.tag.Tag
 
 object HotMBlockTags {
-    val LEYLINES = TagRegistry.block(HotMConstants.identifier("leylines"))
-    val PLASSEIN_FERTILE = TagRegistry.block(HotMConstants.identifier("plassein_fertile"))
-    val PLASSEIN_SOURCE = TagRegistry.block(HotMConstants.identifier("plassein_source"))
-    val SCAFFOLDING = TagRegistry.block(HotMConstants.identifier("scaffolding"))
+    lateinit var LEYLINES: Tag<Block>
+        private set
+    lateinit var PLASSEIN_FERTILE: Tag<Block>
+        private set
+    lateinit var PLASSEIN_SOURCE: Tag<Block>
+        private set
+    lateinit var SCAFFOLDING: Tag<Block>
+        private set
+
+    fun register() {
+        LEYLINES = TagRegistry.block(HotMConstants.identifier("leylines"))
+        PLASSEIN_FERTILE = TagRegistry.block(HotMConstants.identifier("plassein_fertile"))
+        PLASSEIN_SOURCE = TagRegistry.block(HotMConstants.identifier("plassein_source"))
+        SCAFFOLDING = TagRegistry.block(HotMConstants.identifier("scaffolding"))
+    }
 }

--- a/src/main/kotlin/com/github/hotm/misc/HotMProperties.kt
+++ b/src/main/kotlin/com/github/hotm/misc/HotMProperties.kt
@@ -4,5 +4,5 @@ import net.minecraft.state.property.IntProperty
 
 object HotMProperties {
     const val MAX_DISTANCE = 16
-    val DISTANCE: IntProperty = IntProperty.of("distance", 1, MAX_DISTANCE)
+    val DISTANCE: IntProperty by lazy { IntProperty.of("distance", 1, MAX_DISTANCE) }
 }

--- a/src/main/kotlin/com/github/hotm/misc/HotMRegistries.kt
+++ b/src/main/kotlin/com/github/hotm/misc/HotMRegistries.kt
@@ -16,21 +16,30 @@ object HotMRegistries {
 
     // keys
 
-    val UNIT_FEATURE_SEGMENT_TYPE_KEY =
+    val UNIT_FEATURE_SEGMENT_TYPE_KEY by lazy {
         RegistryKey.ofRegistry<FeatureSegmentType<Unit, *>>(UNIT_FEATURE_SEGMENT_TYPE_IDENTIFIER)
-    val CARDINAL_FEATURE_SEGMENT_TYPE_KEY =
+    }
+    val CARDINAL_FEATURE_SEGMENT_TYPE_KEY by lazy {
         RegistryKey.ofRegistry<FeatureSegmentType<CardinalDirection, *>>(CARDINAL_FEATURE_SEGMENT_TYPE_IDENTIFIER)
+    }
 
     // registries
 
-    val UNIT_FEATURE_SEGMENT_TYPE = Registry.register(
-        Registry.REGISTRIES as Registry<in Registry<*>>,
-        UNIT_FEATURE_SEGMENT_TYPE_IDENTIFIER,
-        SimpleRegistry(UNIT_FEATURE_SEGMENT_TYPE_KEY, Lifecycle.experimental())
-    )
-    val CARDINAL_FEATURE_SEGMENT_TYPE = Registry.register(
-        Registry.REGISTRIES as Registry<Registry<*>>,
-        CARDINAL_FEATURE_SEGMENT_TYPE_IDENTIFIER,
-        SimpleRegistry(CARDINAL_FEATURE_SEGMENT_TYPE_KEY, Lifecycle.experimental())
-    )
+    lateinit var UNIT_FEATURE_SEGMENT_TYPE: Registry<FeatureSegmentType<Unit, *>>
+        private set
+    lateinit var CARDINAL_FEATURE_SEGMENT_TYPE: Registry<FeatureSegmentType<CardinalDirection, *>>
+        private set
+
+    fun register() {
+        UNIT_FEATURE_SEGMENT_TYPE = Registry.register(
+            Registry.REGISTRIES as Registry<in Registry<*>>,
+            UNIT_FEATURE_SEGMENT_TYPE_IDENTIFIER,
+            SimpleRegistry(UNIT_FEATURE_SEGMENT_TYPE_KEY, Lifecycle.experimental())
+        )
+        CARDINAL_FEATURE_SEGMENT_TYPE = Registry.register(
+            Registry.REGISTRIES as Registry<Registry<*>>,
+            CARDINAL_FEATURE_SEGMENT_TYPE_IDENTIFIER,
+            SimpleRegistry(CARDINAL_FEATURE_SEGMENT_TYPE_KEY, Lifecycle.experimental())
+        )
+    }
 }

--- a/src/main/kotlin/com/github/hotm/world/HotMDimensions.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMDimensions.kt
@@ -20,6 +20,7 @@ import net.minecraft.world.World
 import net.minecraft.world.biome.Biome
 import net.minecraft.world.biome.source.HorizontalVoronoiBiomeAccessType
 import net.minecraft.world.biome.source.MultiNoiseBiomeSource
+import net.minecraft.world.dimension.DimensionOptions
 import net.minecraft.world.dimension.DimensionType
 import net.minecraft.world.gen.chunk.*
 import java.util.*
@@ -34,100 +35,48 @@ object HotMDimensions {
     /**
      * Key used to reference the Nectere dimension.
      */
-    val NECTERE_KEY: RegistryKey<World> =
+    val NECTERE_KEY: RegistryKey<World> by lazy {
         RegistryKey.of(Registry.WORLD_KEY, HotMConstants.identifier("nectere"))
+    }
 
     /**
      * Key used to reference the Nectere dimension options.
      */
-    val NECTERE_OPTIONS_KEY = RegistryKey.of(Registry.DIMENSION_KEY, HotMConstants.identifier("nectere"))
-
-    /**
-     * Dimension options that describe the Nectere dimension.
-     */
-    val NECTERE_TYPE = DimensionType.create(
-        OptionalLong.empty(),
-        true,
-        false,
-        false,
-        true,
-        1.0,
-        false,
-        false,
-        false,
-        false,
-        false,
-        0,
-        256,
-        256,
-        HorizontalVoronoiBiomeAccessType.INSTANCE,
-        BlockTags.INFINIBURN_OVERWORLD.id,
-        DimensionType.OVERWORLD_ID,
-        0.1f
-    )
+    val NECTERE_OPTIONS_KEY: RegistryKey<DimensionOptions> by lazy {
+        RegistryKey.of(Registry.DIMENSION_KEY, HotMConstants.identifier("nectere"))
+    }
 
     /**
      * Key used to reference the Nectere dimension type.
      */
-    val NECTERE_TYPE_KEY = RegistryKey.of(Registry.DIMENSION_TYPE_KEY, HotMConstants.identifier("nectere"))
+    val NECTERE_TYPE_KEY by lazy {
+        RegistryKey.of(Registry.DIMENSION_TYPE_KEY, HotMConstants.identifier("nectere"))
+    }
 
     /**
      * The registry key for the Nectere chunk generator settings.
      */
-    val NECTERE_CHUNK_GENERATOR_SETTINGS_KEY =
+    val NECTERE_CHUNK_GENERATOR_SETTINGS_KEY by lazy {
         RegistryKey.of(Registry.CHUNK_GENERATOR_SETTINGS_KEY, HotMConstants.identifier("nectere"))
+    }
+
+    /**
+     * Dimension options that describe the Nectere dimension.
+     */
+    lateinit var NECTERE_TYPE: DimensionType
+        private set
 
     /**
      * ChunkGeneratorType preset for the Nectere dimension.
      */
-    val NECTERE_CHUNK_GENERATOR_SETTINGS_BUILTIN = Registry.register(
-        BuiltinRegistries.CHUNK_GENERATOR_SETTINGS,
-        NECTERE_CHUNK_GENERATOR_SETTINGS_KEY.value,
-        ChunkGeneratorSettingsAccess.create(
-            StructuresConfig(false),
-            GenerationShapeConfig.create(
-                0,
-                160,
-                NoiseSamplingConfig(0.9999999814507745, 0.9999999814507745, 80.0, 60.0),
-                SlideConfig(-10, 3, 0),
-                SlideConfig(50, 4, -1),
-                1,
-                2,
-                -0.02,
-                -0.02,
-                true,
-                true,
-                false,
-                false
-            ),
-            HotMBlocks.THINKING_STONE.defaultState,
-            Blocks.WATER.defaultState,
-            -10,
-            0,
-            16,
-            0,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        )
-    )
+    lateinit var NECTERE_CHUNK_GENERATOR_SETTINGS_BUILTIN: ChunkGeneratorSettings
+        private set
 
     /**
      * Biome source preset for the Nectere dimension.
      */
-    val NECTERE_BIOME_SOURCE_PRESET =
-        MultiNoiseBiomeSource.Preset(HotMConstants.identifier("nectere")) { preset, registry, seed ->
-            MultiNoiseBiomeSourceAccess.create(
-                seed,
-                HotMBiomes.biomeNoise().entries.stream().map<Pair<Biome.MixedNoisePoint, Supplier<Biome>>> { entry ->
-                    Pair.of(entry.value, Supplier { registry.getOrThrow(entry.key) })
-                }.collect(ImmutableList.toImmutableList()),
-                Optional.of(Pair.of(registry, preset))
-            )
-        }
+    lateinit var NECTERE_BIOME_SOURCE_PRESET: MultiNoiseBiomeSource.Preset
+        private set
 
     /**
      * Calls this Registers this mods dimensions.
@@ -146,6 +95,74 @@ object HotMDimensions {
      * Registers the world generator for the Nectere dimension.
      */
     private fun registerImpl() {
+        NECTERE_TYPE = DimensionType.create(
+            OptionalLong.empty(),
+            true,
+            false,
+            false,
+            true,
+            1.0,
+            false,
+            false,
+            false,
+            false,
+            false,
+            0,
+            256,
+            256,
+            HorizontalVoronoiBiomeAccessType.INSTANCE,
+            BlockTags.INFINIBURN_OVERWORLD.id,
+            DimensionType.OVERWORLD_ID,
+            0.1f
+        )
+
+        NECTERE_CHUNK_GENERATOR_SETTINGS_BUILTIN = Registry.register(
+            BuiltinRegistries.CHUNK_GENERATOR_SETTINGS,
+            NECTERE_CHUNK_GENERATOR_SETTINGS_KEY.value,
+            ChunkGeneratorSettingsAccess.create(
+                StructuresConfig(false),
+                GenerationShapeConfig.create(
+                    0,
+                    160,
+                    NoiseSamplingConfig(0.9999999814507745, 0.9999999814507745, 80.0, 60.0),
+                    SlideConfig(-10, 3, 0),
+                    SlideConfig(50, 4, -1),
+                    1,
+                    2,
+                    -0.02,
+                    -0.02,
+                    true,
+                    true,
+                    false,
+                    false
+                ),
+                HotMBlocks.THINKING_STONE.defaultState,
+                Blocks.WATER.defaultState,
+                -10,
+                0,
+                16,
+                0,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true
+            )
+        )
+
+        NECTERE_BIOME_SOURCE_PRESET =
+            MultiNoiseBiomeSource.Preset(HotMConstants.identifier("nectere")) { preset, registry, seed ->
+                MultiNoiseBiomeSourceAccess.create(
+                    seed,
+                    HotMBiomes.biomeNoise().entries.stream()
+                        .map<Pair<Biome.MixedNoisePoint, Supplier<Biome>>> { entry ->
+                            Pair.of(entry.value, Supplier { registry.getOrThrow(entry.key) })
+                        }.collect(ImmutableList.toImmutableList()),
+                    Optional.of(Pair.of(registry, preset))
+                )
+            }
+
         Registry.register(
             Registry.CHUNK_GENERATOR,
             HotMConstants.identifier("nectere"),

--- a/src/main/kotlin/com/github/hotm/world/HotMDimensions.kt
+++ b/src/main/kotlin/com/github/hotm/world/HotMDimensions.kt
@@ -30,7 +30,6 @@ import java.util.function.Supplier
  * Initializes and registers dimension functionality.
  */
 object HotMDimensions {
-    private var registered = false
 
     /**
      * Key used to reference the Nectere dimension.
@@ -79,22 +78,9 @@ object HotMDimensions {
         private set
 
     /**
-     * Calls this Registers this mods dimensions.
-     *
-     * Actual registration happens in a separate method that is protected from being called twice so that servers, which
-     * query dimensions before mods are loaded, can call this register method when loading.
-     */
-    fun register() {
-        if (!registered) {
-            registered = true
-            registerImpl()
-        }
-    }
-
-    /**
      * Registers the world generator for the Nectere dimension.
      */
-    private fun registerImpl() {
+    fun register() {
         NECTERE_TYPE = DimensionType.create(
             OptionalLong.empty(),
             true,

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/HotMFeatures.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/HotMFeatures.kt
@@ -2,6 +2,7 @@ package com.github.hotm.world.gen.feature
 
 import com.github.hotm.HotMConstants
 import com.github.hotm.world.gen.feature.decorator.HotMDecorators
+import com.github.hotm.world.gen.feature.segment.HotMFeatureSegmentTypes
 import com.github.hotm.world.gen.feature.segment.SegmentedFeature
 import com.github.hotm.world.gen.feature.segment.SegmentedFeatureConfig
 import net.minecraft.util.registry.Registry
@@ -77,6 +78,7 @@ object HotMFeatures {
             register("nns_nectere_portal", NecterePortalFeature(DefaultFeatureConfig.CODEC))
 
         HotMDecorators.register()
+        HotMFeatureSegmentTypes.register()
 
         HotMStructureFeatures.register()
 

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/HotMFeatures.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/HotMFeatures.kt
@@ -1,6 +1,7 @@
 package com.github.hotm.world.gen.feature
 
 import com.github.hotm.HotMConstants
+import com.github.hotm.world.gen.feature.decorator.HotMDecorators
 import com.github.hotm.world.gen.feature.segment.SegmentedFeature
 import com.github.hotm.world.gen.feature.segment.SegmentedFeatureConfig
 import net.minecraft.util.registry.Registry
@@ -74,6 +75,8 @@ object HotMFeatures {
         TRANSMISSION_TOWER = register("transmission_tower", TransmissionTowerFeature(TransmissionTowerConfig.CODEC))
         NON_NECTERE_SIDE_NECTERE_PORTAL =
             register("nns_nectere_portal", NecterePortalFeature(DefaultFeatureConfig.CODEC))
+
+        HotMDecorators.register()
 
         HotMStructureFeatures.register()
 

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/decorator/HotMDecorators.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/decorator/HotMDecorators.kt
@@ -8,21 +8,28 @@ import net.minecraft.util.registry.Registry
  * Keeps track of the Heart of the Machine decorators.
  */
 object HotMDecorators {
-    val COUNT_HEIGHTMAP_IN_RANGE: CountHeightmapInRangeDecorator = Registry.register(
-        Registry.DECORATOR,
-        HotMConstants.identifier("count_heightmap_in_range"),
-        CountHeightmapInRangeDecorator(CountHeightmapInRangeDecoratorConfig.CODEC)
-    )
+    lateinit var COUNT_HEIGHTMAP_IN_RANGE: CountHeightmapInRangeDecorator
+        private set
+    lateinit var COUNT_CHANCE_SURFACE_IN_RANGE: CountChanceSurfaceInRangeDecorator
+        private set
+    lateinit var COUNT_CHANCE_HEIGHTMAP_IN_RANGE: CountChanceHeightmapInRangeDecorator
+        private set
 
-    val COUNT_CHANCE_SURFACE_IN_RANGE: CountChanceSurfaceInRangeDecorator = Registry.register(
-        Registry.DECORATOR,
-        HotMConstants.identifier("count_chance_surface_in_range"),
-        CountChanceSurfaceInRangeDecorator(CountChanceInRangeDecoratorConfig.CODEC)
-    )
-
-    val COUNT_CHANCE_HEIGHTMAP_IN_RANGE: CountChanceHeightmapInRangeDecorator = Registry.register(
-        Registry.DECORATOR,
-        HotMConstants.identifier("count_chance_heightmap_in_range"),
-        CountChanceHeightmapInRangeDecorator(CountChanceInRangeDecoratorConfig.CODEC)
-    )
+    fun register() {
+        COUNT_HEIGHTMAP_IN_RANGE = Registry.register(
+            Registry.DECORATOR,
+            HotMConstants.identifier("count_heightmap_in_range"),
+            CountHeightmapInRangeDecorator(CountHeightmapInRangeDecoratorConfig.CODEC)
+        )
+        COUNT_CHANCE_SURFACE_IN_RANGE = Registry.register(
+            Registry.DECORATOR,
+            HotMConstants.identifier("count_chance_surface_in_range"),
+            CountChanceSurfaceInRangeDecorator(CountChanceInRangeDecoratorConfig.CODEC)
+        )
+        COUNT_CHANCE_HEIGHTMAP_IN_RANGE = Registry.register(
+            Registry.DECORATOR,
+            HotMConstants.identifier("count_chance_heightmap_in_range"),
+            CountChanceHeightmapInRangeDecorator(CountChanceInRangeDecoratorConfig.CODEC)
+        )
+    }
 }

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/segment/FeatureSegment.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/segment/FeatureSegment.kt
@@ -13,16 +13,18 @@ import java.util.*
  */
 interface FeatureSegment<C> {
     companion object {
-        val UNIT_CODEC: Codec<FeatureSegment<Unit>> =
-            HotMRegistries.UNIT_FEATURE_SEGMENT_TYPE.dispatch<FeatureSegment<Unit>>(
+        val UNIT_CODEC: Codec<FeatureSegment<Unit>> by lazy {
+            HotMRegistries.UNIT_FEATURE_SEGMENT_TYPE.dispatch(
                 FeatureSegment<Unit>::type,
                 FeatureSegmentType<Unit, out FeatureSegment<Unit>>::codec
             )
-        val CARDINAL_CODEC: Codec<FeatureSegment<CardinalDirection>> =
-            HotMRegistries.CARDINAL_FEATURE_SEGMENT_TYPE.dispatch<FeatureSegment<CardinalDirection>>(
+        }
+        val CARDINAL_CODEC: Codec<FeatureSegment<CardinalDirection>> by lazy {
+            HotMRegistries.CARDINAL_FEATURE_SEGMENT_TYPE.dispatch(
                 FeatureSegment<CardinalDirection>::type,
                 FeatureSegmentType<CardinalDirection, out FeatureSegment<CardinalDirection>>::codec
             )
+        }
     }
 
     val type: FeatureSegmentType<C, *>

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/segment/FeatureSegmentType.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/segment/FeatureSegmentType.kt
@@ -1,43 +1,8 @@
 package com.github.hotm.world.gen.feature.segment
 
-import com.github.hotm.HotMConstants
-import com.github.hotm.misc.HotMRegistries
-import com.github.hotm.util.CardinalDirection
 import com.mojang.serialization.Codec
-import net.minecraft.util.registry.Registry
 
 /**
  * A type of feature part.
  */
-class FeatureSegmentType<C, S : FeatureSegment<C>>(val codec: Codec<S>) {
-    companion object {
-        val PLASSEIN_STEM_FEATURE_SEGMENT =
-            registerUnit("plassein_stem_feature_segment", PlasseinStemSegment.CODEC)
-        val PLASSEIN_BRANCH_FEATURE_SEGMENT =
-            registerCardinal("plassein_branch_feature_segment", PlasseinBranchSegment.CODEC)
-        val PLASSEIN_LEAF_FEATURE_SEGMENT =
-            registerUnit("plassein_leaf_feature_segment", PlasseinLeafSegment.CODEC)
-
-        private fun <S : FeatureSegment<Unit>> registerUnit(
-            name: String,
-            codec: Codec<S>
-        ): FeatureSegmentType<Unit, S> {
-            return Registry.register(
-                HotMRegistries.UNIT_FEATURE_SEGMENT_TYPE,
-                HotMConstants.identifier(name),
-                FeatureSegmentType(codec)
-            )
-        }
-
-        private fun <S : FeatureSegment<CardinalDirection>> registerCardinal(
-            name: String,
-            codec: Codec<S>
-        ): FeatureSegmentType<CardinalDirection, S> {
-            return Registry.register(
-                HotMRegistries.CARDINAL_FEATURE_SEGMENT_TYPE,
-                HotMConstants.identifier(name),
-                FeatureSegmentType(codec)
-            )
-        }
-    }
-}
+class FeatureSegmentType<C, S : FeatureSegment<C>>(val codec: Codec<S>)

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/segment/HotMFeatureSegmentTypes.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/segment/HotMFeatureSegmentTypes.kt
@@ -1,0 +1,45 @@
+package com.github.hotm.world.gen.feature.segment
+
+import com.github.hotm.HotMConstants
+import com.github.hotm.misc.HotMRegistries
+import com.github.hotm.util.CardinalDirection
+import com.mojang.serialization.Codec
+import net.minecraft.util.registry.Registry
+
+object HotMFeatureSegmentTypes {
+    lateinit var PLASSEIN_STEM_FEATURE_SEGMENT: FeatureSegmentType<Unit, PlasseinStemSegment>
+        private set
+    lateinit var PLASSEIN_BRANCH_FEATURE_SEGMENT: FeatureSegmentType<CardinalDirection, PlasseinBranchSegment>
+        private set
+    lateinit var PLASSEIN_LEAF_FEATURE_SEGMENT: FeatureSegmentType<Unit, PlasseinLeafSegment>
+        private set
+
+    fun register() {
+        PLASSEIN_STEM_FEATURE_SEGMENT = registerUnit("plassein_stem_feature_segment", PlasseinStemSegment.CODEC)
+        PLASSEIN_BRANCH_FEATURE_SEGMENT =
+            registerCardinal("plassein_branch_feature_segment", PlasseinBranchSegment.CODEC)
+        PLASSEIN_LEAF_FEATURE_SEGMENT = registerUnit("plassein_leaf_feature_segment", PlasseinLeafSegment.CODEC)
+    }
+
+    private fun <S : FeatureSegment<Unit>> registerUnit(
+        name: String,
+        codec: Codec<S>
+    ): FeatureSegmentType<Unit, S> {
+        return Registry.register(
+            HotMRegistries.UNIT_FEATURE_SEGMENT_TYPE,
+            HotMConstants.identifier(name),
+            FeatureSegmentType(codec)
+        )
+    }
+
+    private fun <S : FeatureSegment<CardinalDirection>> registerCardinal(
+        name: String,
+        codec: Codec<S>
+    ): FeatureSegmentType<CardinalDirection, S> {
+        return Registry.register(
+            HotMRegistries.CARDINAL_FEATURE_SEGMENT_TYPE,
+            HotMConstants.identifier(name),
+            FeatureSegmentType(codec)
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hotm/world/gen/feature/segment/PlasseinGrowthSegments.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/feature/segment/PlasseinGrowthSegments.kt
@@ -1,9 +1,9 @@
 package com.github.hotm.world.gen.feature.segment
 
+import com.github.hotm.util.CardinalDirection
 import com.github.hotm.world.gen.feature.FeatureUtils
 import com.github.hotm.world.gen.feature.segment.FeatureSegmentUtils.tryFill
 import com.github.hotm.world.gen.feature.segment.FeatureSegmentUtils.tryPlace
-import com.github.hotm.util.CardinalDirection
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import com.terraformersmc.terraform.shapes.api.Position
@@ -45,7 +45,7 @@ class PlasseinStemSegment(
             }
     }
 
-    override val type = FeatureSegmentType.PLASSEIN_STEM_FEATURE_SEGMENT
+    override val type = HotMFeatureSegmentTypes.PLASSEIN_STEM_FEATURE_SEGMENT
 
     override fun tryGenerate(
         blocks: MutableMap<BlockPos, BlockPlacement>,
@@ -120,7 +120,7 @@ class PlasseinBranchSegment(
             }
     }
 
-    override val type = FeatureSegmentType.PLASSEIN_BRANCH_FEATURE_SEGMENT
+    override val type = HotMFeatureSegmentTypes.PLASSEIN_BRANCH_FEATURE_SEGMENT
 
     override fun tryGenerate(
         blocks: MutableMap<BlockPos, BlockPlacement>,
@@ -207,7 +207,7 @@ class PlasseinLeafSegment(
             }
     }
 
-    override val type = FeatureSegmentType.PLASSEIN_LEAF_FEATURE_SEGMENT
+    override val type = HotMFeatureSegmentTypes.PLASSEIN_LEAF_FEATURE_SEGMENT
 
     override fun tryGenerate(
         blocks: MutableMap<BlockPos, BlockPlacement>,

--- a/src/main/kotlin/com/github/hotm/world/gen/surfacebuilder/HotMConfiguredSurfaceBuilders.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/surfacebuilder/HotMConfiguredSurfaceBuilders.kt
@@ -14,14 +14,18 @@ object HotMConfiguredSurfaceBuilders {
     /**
      * Thinking Forest biome surface builder.
      */
-    val THINKING_FOREST =
-        register("thinking_forest", HotMSurfaceBuilders.PARTIAL.withConfig(HotMSurfaceBuilders.GRASS_CONFIG))
+    lateinit var THINKING_FOREST: ConfiguredSurfaceBuilder<NectereSurfaceConfig>
 
     /**
      * Wasteland biome surface builder.
      */
-    val WASTELAND =
-        register("wasteland", HotMSurfaceBuilders.DEFAULT.withConfig(HotMSurfaceBuilders.WASTELAND_CONFIG))
+    lateinit var WASTELAND: ConfiguredSurfaceBuilder<NectereSurfaceConfig>
+
+    fun register() {
+        THINKING_FOREST =
+            register("thinking_forest", HotMSurfaceBuilders.PARTIAL.withConfig(HotMSurfaceBuilders.GRASS_CONFIG))
+        WASTELAND = register("wasteland", HotMSurfaceBuilders.DEFAULT.withConfig(HotMSurfaceBuilders.WASTELAND_CONFIG))
+    }
 
     /**
      * Used for statically registering configured surface builders.

--- a/src/main/kotlin/com/github/hotm/world/gen/surfacebuilder/HotMSurfaceBuilders.kt
+++ b/src/main/kotlin/com/github/hotm/world/gen/surfacebuilder/HotMSurfaceBuilders.kt
@@ -1,27 +1,37 @@
 package com.github.hotm.world.gen.surfacebuilder
 
-import com.github.hotm.blocks.HotMBlocks
 import com.github.hotm.HotMConstants
+import com.github.hotm.blocks.HotMBlocks
 import net.minecraft.util.registry.Registry
 import net.minecraft.world.gen.surfacebuilder.SurfaceBuilder
 import net.minecraft.world.gen.surfacebuilder.SurfaceConfig
 
 object HotMSurfaceBuilders {
-    val GRASS_BLOCK = HotMBlocks.PLASSEIN_GRASS
-    val RUSTED_SURFACE_BLOCK = HotMBlocks.RUSTED_MACHINE_CASING
-    val SAND_BLOCK = HotMBlocks.NULL_SAND
-    val SURFACE_BLOCK = HotMBlocks.SURFACE_MACHINE_CASING
+    val GRASS_BLOCK by lazy { HotMBlocks.PLASSEIN_GRASS }
+    val RUSTED_SURFACE_BLOCK by lazy { HotMBlocks.RUSTED_MACHINE_CASING }
+    val SAND_BLOCK by lazy { HotMBlocks.NULL_SAND }
+    val SURFACE_BLOCK by lazy { HotMBlocks.SURFACE_MACHINE_CASING }
 
-    private val GRASS_STATE = GRASS_BLOCK.defaultState
-    private val RUSTED_SURFACE_STATE = RUSTED_SURFACE_BLOCK.defaultState
-    private val SAND_STATE = SAND_BLOCK.defaultState
-    private val SURFACE_STATE = SURFACE_BLOCK.defaultState
+    private val GRASS_STATE by lazy { GRASS_BLOCK.defaultState }
+    private val RUSTED_SURFACE_STATE by lazy { RUSTED_SURFACE_BLOCK.defaultState }
+    private val SAND_STATE by lazy { SAND_BLOCK.defaultState }
+    private val SURFACE_STATE by lazy { SURFACE_BLOCK.defaultState }
 
-    val GRASS_CONFIG = NectereSurfaceConfig(GRASS_STATE, SURFACE_STATE, SAND_STATE)
-    val WASTELAND_CONFIG = NectereSurfaceConfig(RUSTED_SURFACE_STATE, SURFACE_STATE, SAND_STATE)
+    lateinit var GRASS_CONFIG: NectereSurfaceConfig
+    lateinit var WASTELAND_CONFIG: NectereSurfaceConfig
 
-    val DEFAULT = register("default", NectereSurfaceBuilder(NectereSurfaceConfig.CODEC))
-    val PARTIAL = register("partial", NecterePartialSurfaceBuilder(NectereSurfaceConfig.CODEC))
+    lateinit var DEFAULT: NectereSurfaceBuilder
+    lateinit var PARTIAL: NecterePartialSurfaceBuilder
+
+    fun register() {
+        GRASS_CONFIG = NectereSurfaceConfig(GRASS_STATE, SURFACE_STATE, SAND_STATE)
+        WASTELAND_CONFIG = NectereSurfaceConfig(RUSTED_SURFACE_STATE, SURFACE_STATE, SAND_STATE)
+
+        DEFAULT = register("default", NectereSurfaceBuilder(NectereSurfaceConfig.CODEC))
+        PARTIAL = register("partial", NecterePartialSurfaceBuilder(NectereSurfaceConfig.CODEC))
+
+        HotMConfiguredSurfaceBuilders.register()
+    }
 
     private fun <C : SurfaceConfig?, F : SurfaceBuilder<C>> register(string: String, surfaceBuilder: F): F {
         return Registry.register(Registry.SURFACE_BUILDER, HotMConstants.identifier(string), surfaceBuilder)


### PR DESCRIPTION
This PR moves most mod initialization into `register()` and `init()` methods to avoid loading parts of Minecraft too early and to have more control over the order in which parts of the mod get initialized.