### PR TITLE
Aura net refactor

### DIFF
--- a/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
+++ b/src/main/kotlin/com/github/hotm/HeartOfTheMachineMod.kt
@@ -11,7 +11,7 @@ import com.github.hotm.net.sync.ServerSync2ClientData
 import com.github.hotm.particle.HotMParticles
 import com.github.hotm.world.HotMDimensions
 import com.github.hotm.world.HotMTeleporters
-import com.github.hotm.world.auranet.AuraNodes
+import com.github.hotm.auranet.AuraNodes
 import com.github.hotm.world.biome.HotMBiomes
 import com.github.hotm.world.gen.feature.HotMFeatures
 import com.github.hotm.world.gen.surfacebuilder.HotMSurfaceBuilders

--- a/src/main/kotlin/com/github/hotm/auranet/AbstractAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AbstractAuraNode.kt
@@ -1,6 +1,7 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.util.DimBlockPos
+import com.github.hotm.world.auranet.AuraNetAccess
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.registry.RegistryKey
 import net.minecraft.world.World

--- a/src/main/kotlin/com/github/hotm/auranet/AbstractDependableAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AbstractDependableAuraNode.kt
@@ -1,0 +1,19 @@
+package com.github.hotm.auranet
+
+import com.github.hotm.world.auranet.AuraNetAccess
+import net.minecraft.util.math.BlockPos
+
+abstract class AbstractDependableAuraNode(
+    type: AuraNodeType<out AuraNode>,
+    access: AuraNetAccess,
+    updateListener: Runnable?,
+    pos: BlockPos
+) : AbstractAuraNode(type, access, updateListener, pos), DependableAuraNode {
+    override fun onRemove() {
+        disconnectAll()
+    }
+
+    protected fun disconnectAll() {
+        DependencyAuraNodeUtils.parentDisconnectAll(getChildren(), access, this)
+    }
+}

--- a/src/main/kotlin/com/github/hotm/auranet/AbstractDependantAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AbstractDependantAuraNode.kt
@@ -1,0 +1,21 @@
+package com.github.hotm.auranet
+
+import com.github.hotm.world.auranet.AuraNetAccess
+import net.minecraft.util.math.BlockPos
+
+abstract class AbstractDependantAuraNode(
+    type: AuraNodeType<out AuraNode>,
+    access: AuraNetAccess,
+    updateListener: Runnable?,
+    pos: BlockPos
+) : AbstractAuraNode(type, access, updateListener, pos), DependantAuraNode {
+    abstract fun getParents(): Collection<BlockPos>
+
+    override fun onRemove() {
+        disconnectAll()
+    }
+
+    protected fun disconnectAll() {
+        DependencyAuraNodeUtils.childDisconnectAll(getParents(), access, this)
+    }
+}

--- a/src/main/kotlin/com/github/hotm/auranet/AbstractDependantDependableAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AbstractDependantDependableAuraNode.kt
@@ -1,0 +1,22 @@
+package com.github.hotm.auranet
+
+import com.github.hotm.world.auranet.AuraNetAccess
+import net.minecraft.util.math.BlockPos
+
+abstract class AbstractDependantDependableAuraNode(
+    type: AuraNodeType<out AuraNode>,
+    access: AuraNetAccess,
+    updateListener: Runnable?,
+    pos: BlockPos
+) : AbstractAuraNode(type, access, updateListener, pos), DependantAuraNode, DependableAuraNode {
+    abstract fun getParents(): Collection<BlockPos>
+
+    override fun onRemove() {
+        disconnectAll()
+    }
+
+    protected fun disconnectAll() {
+        DependencyAuraNodeUtils.childDisconnectAll(getParents(), access, this)
+        DependencyAuraNodeUtils.parentDisconnectAll(getChildren(), access, this)
+    }
+}

--- a/src/main/kotlin/com/github/hotm/auranet/AttributeProviderAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AttributeProviderAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.attributes.AttributeList
 

--- a/src/main/kotlin/com/github/hotm/auranet/AuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AuraNode.kt
@@ -152,8 +152,6 @@ interface AuraNode {
 
     val dimPos: DimBlockPos
 
-    fun getValue(): Float
-
     fun writeToPacket(buf: NetByteBuf, ctx: IMsgWriteCtx)
 
     fun onRemove() {}

--- a/src/main/kotlin/com/github/hotm/auranet/AuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -11,6 +11,7 @@ import com.github.hotm.misc.HotMRegistries
 import com.github.hotm.mixinapi.StorageUtils
 import com.github.hotm.net.HotMNetwork
 import com.github.hotm.util.DimBlockPos
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.*
 import net.minecraft.util.math.BlockPos
 import org.apache.logging.log4j.LogManager

--- a/src/main/kotlin/com/github/hotm/auranet/AuraNodeType.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AuraNodeType.kt
@@ -1,7 +1,8 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.NetByteBuf
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import net.minecraft.util.math.BlockPos
 

--- a/src/main/kotlin/com/github/hotm/auranet/AuraNodeUtils.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AuraNodeUtils.kt
@@ -1,6 +1,7 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.mixinapi.StorageUtils
+import com.github.hotm.world.auranet.AuraNetAccess
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
 

--- a/src/main/kotlin/com/github/hotm/auranet/AuraNodes.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/AuraNodes.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.HotMConstants
 import com.github.hotm.misc.HotMRegistries

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
@@ -22,7 +22,7 @@ class BasicSiphonAuraNode(
     pos: BlockPos,
     private var value: Float,
     childPos: BlockPos?
-) : AbstractAuraNode(Type, access, updateListener, pos), SiphonAuraNode, RenderedDependableAuraNode, ValuedAuraNode {
+) : AbstractDependableAuraNode(Type, access, updateListener, pos), SiphonAuraNode, RenderedDependableAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(
@@ -116,8 +116,8 @@ class BasicSiphonAuraNode(
         return value
     }
 
-    override fun getChildren(): Stream<BlockPos> {
-        return StreamUtils.ofNullable(childPos)
+    override fun getChildren(): Collection<BlockPos> {
+        return setOfNotNull(childPos)
     }
 
     override fun getChildrenForRender(): Stream<BlockPos> {
@@ -144,11 +144,6 @@ class BasicSiphonAuraNode(
         } else {
             buf.writeBoolean(false)
         }
-    }
-
-    override fun onRemove() {
-        // Remove self from the child's parents
-        DependencyAuraNodeUtils.parentDisconnect(childPos, access, this)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
@@ -22,7 +22,7 @@ class BasicSiphonAuraNode(
     pos: BlockPos,
     private var value: Float,
     childPos: BlockPos?
-) : AbstractAuraNode(Type, access, updateListener, pos), SiphonAuraNode, RenderedDependableAuraNode {
+) : AbstractAuraNode(Type, access, updateListener, pos), SiphonAuraNode, RenderedDependableAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSiphonAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -9,6 +9,7 @@ import com.github.hotm.net.sendToClients
 import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.util.StreamUtils
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
@@ -22,7 +22,7 @@ class BasicSourceAuraNode(
     pos: BlockPos,
     private var value: Float,
     parents: Collection<BlockPos>
-) : AbstractAuraNode(Type, access, updateListener, pos), SourceAuraNode, DependantAuraNode, ValuedAuraNode {
+) : AbstractDependantAuraNode(Type, access, updateListener, pos), SourceAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(BasicSourceAuraNode::class.java, str("basic_source_aura_node"))
@@ -119,9 +119,7 @@ class BasicSourceAuraNode(
         visitedNodes.remove(dimPos)
     }
 
-    override fun onRemove() {
-        DependencyAuraNodeUtils.childDisconnectAll(parents, access, this)
-    }
+    override fun getParents(): Collection<BlockPos> = parents
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -10,6 +10,7 @@ import com.github.hotm.net.sendToClients
 import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.util.StreamUtils
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/BasicSourceAuraNode.kt
@@ -22,7 +22,7 @@ class BasicSourceAuraNode(
     pos: BlockPos,
     private var value: Float,
     parents: Collection<BlockPos>
-) : AbstractAuraNode(Type, access, updateListener, pos), SourceAuraNode, DependantAuraNode {
+) : AbstractAuraNode(Type, access, updateListener, pos), SourceAuraNode, DependantAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(BasicSourceAuraNode::class.java, str("basic_source_aura_node"))

--- a/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
@@ -23,7 +23,7 @@ class CollectorDistributorAuraNode(
     private var value: Float,
     parents: Collection<BlockPos>,
     children: Collection<BlockPos>
-) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, RenderedDependableAuraNode {
+) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, RenderedDependableAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(

--- a/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -10,6 +10,7 @@ import com.github.hotm.net.sendToClients
 import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.util.StreamUtils
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/CollectorDistributorAuraNode.kt
@@ -23,7 +23,7 @@ class CollectorDistributorAuraNode(
     private var value: Float,
     parents: Collection<BlockPos>,
     children: Collection<BlockPos>
-) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, RenderedDependableAuraNode, ValuedAuraNode {
+) : AbstractDependantDependableAuraNode(Type, access, updateListener, pos), RenderedDependableAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT = AuraNode.NET_ID.subType(
@@ -97,8 +97,8 @@ class CollectorDistributorAuraNode(
         return value / children.size.toFloat()
     }
 
-    override fun getChildren(): Stream<BlockPos> {
-        return children.stream()
+    override fun getChildren(): Collection<BlockPos> {
+        return children
     }
 
     override fun isParentValid(node: DependableAuraNode): Boolean {
@@ -155,6 +155,8 @@ class CollectorDistributorAuraNode(
         visitedNodes.remove(dimPos)
     }
 
+    override fun getParents(): Collection<BlockPos> = parents
+
     override fun getChildrenForRender(): Stream<BlockPos> {
         return children.stream()
     }
@@ -181,15 +183,6 @@ class CollectorDistributorAuraNode(
         for (child in children) {
             buf.writeBlockPos(child)
         }
-    }
-
-    override fun onRemove() {
-        disconnectAll()
-    }
-
-    private fun disconnectAll() {
-        DependencyAuraNodeUtils.childDisconnectAll(parents, access, this)
-        DependencyAuraNodeUtils.parentDisconnectAll(children, access, this)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/github/hotm/auranet/DependableAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/DependableAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import net.minecraft.util.math.BlockPos
 import java.util.stream.Stream

--- a/src/main/kotlin/com/github/hotm/auranet/DependableAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/DependableAuraNode.kt
@@ -59,5 +59,5 @@ interface DependableAuraNode : AuraNode {
     /**
      * Gets all the aura nodes that depend on this aura node.
      */
-    fun getChildren(): Stream<BlockPos>
+    fun getChildren(): Collection<BlockPos>
 }

--- a/src/main/kotlin/com/github/hotm/auranet/DependantAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/DependantAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.util.DimBlockPos
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/auranet/DependencyAuraNodeUtils.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/DependencyAuraNodeUtils.kt
@@ -83,6 +83,15 @@ object DependencyAuraNodeUtils {
      * Disconnects a parent and all children in the collection. This is useful for parent aura nodes.
      */
     fun parentDisconnectAll(children: Collection<BlockPos>, access: AuraNetAccess, parent: DependableAuraNode) {
+        // Handle common cases
+        if (children.isEmpty()) {
+            return
+        }
+        if (children.size == 1) {
+            parentDisconnect(children.first(), access, parent)
+            return
+        }
+
         val childrenCopy = children.toList()
         for (child in childrenCopy) {
             parentDisconnect(child, access, parent)
@@ -102,6 +111,15 @@ object DependencyAuraNodeUtils {
      * Disconnects a child aura node from all parents in the collection. This is useful for child aura nodes.
      */
     fun childDisconnectAll(parents: Collection<BlockPos>, access: AuraNetAccess, child: DependantAuraNode) {
+        // Handle common cases
+        if (parents.isEmpty()) {
+            return
+        }
+        if (parents.size == 1) {
+            childDisconnect(parents.first(), access, child)
+            return
+        }
+
         val parentsCopy = parents.toList()
         for (parent in parentsCopy) {
             childDisconnect(parent, access, child)

--- a/src/main/kotlin/com/github/hotm/auranet/DependencyAuraNodeUtils.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/DependencyAuraNodeUtils.kt
@@ -1,7 +1,8 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.mixinapi.StorageUtils
 import com.github.hotm.util.WorldUtils
+import com.github.hotm.world.auranet.AuraNetAccess
 import net.minecraft.block.BlockState
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.hit.HitResult

--- a/src/main/kotlin/com/github/hotm/auranet/PortalAuraNodeUtils.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalAuraNodeUtils.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.blocks.HotMBlocks
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/auranet/PortalRXAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalRXAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.util.DimBlockPos
 

--- a/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
@@ -24,7 +24,8 @@ class PortalReceiverAuraNode(
     private var value: Float,
     private var childPos: BlockPos?,
     private var valid: Boolean
-) : AbstractAuraNode(Type, access, updateListener, pos), RenderedDependableAuraNode, PortalRXAuraNode, ValuedAuraNode {
+) : AbstractDependableAuraNode(Type, access, updateListener, pos), RenderedDependableAuraNode, PortalRXAuraNode,
+    ValuedAuraNode {
 
     companion object {
         private val NET_PARENT =
@@ -136,7 +137,7 @@ class PortalReceiverAuraNode(
 
     override fun getSuppliedAura(child: DependantAuraNode): Float = value
 
-    override fun getChildren(): Stream<BlockPos> = Stream.ofNullable(childPos)
+    override fun getChildren(): Collection<BlockPos> = setOfNotNull(childPos)
 
     override fun getChildrenForRender(): Stream<BlockPos> = Stream.ofNullable(childPos)
 
@@ -187,10 +188,6 @@ class PortalReceiverAuraNode(
         childPos?.let { buf.writeBlockPos(it) }
 
         buf.writeBoolean(valid)
-    }
-
-    override fun onRemove() {
-        DependencyAuraNodeUtils.parentDisconnect(childPos, access, this)
     }
 
     object Type : AuraNodeType<PortalReceiverAuraNode> {

--- a/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -9,6 +9,7 @@ import com.github.hotm.net.sendToClients
 import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.world.HotMPortalFinders
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalReceiverAuraNode.kt
@@ -24,8 +24,7 @@ class PortalReceiverAuraNode(
     private var value: Float,
     private var childPos: BlockPos?,
     private var valid: Boolean
-) : AbstractAuraNode(Type, access, updateListener, pos), RenderedDependableAuraNode,
-    PortalRXAuraNode {
+) : AbstractAuraNode(Type, access, updateListener, pos), RenderedDependableAuraNode, PortalRXAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT =

--- a/src/main/kotlin/com/github/hotm/auranet/PortalTXAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalTXAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 interface PortalTXAuraNode : AuraNode {
     fun isValid(): Boolean

--- a/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
@@ -11,6 +11,7 @@ import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.util.StreamUtils
 import com.github.hotm.world.HotMPortalFinders
+import com.github.hotm.world.auranet.AuraNetAccess
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
@@ -25,7 +25,7 @@ class PortalTransmitterAuraNode(
     private var value: Float,
     parents: Collection<BlockPos>,
     private var valid: Boolean,
-) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, PortalTXAuraNode, ValuedAuraNode {
+) : AbstractDependantAuraNode(Type, access, updateListener, pos), DependantAuraNode, PortalTXAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT =
@@ -179,8 +179,10 @@ class PortalTransmitterAuraNode(
         buf.writeBoolean(valid)
     }
 
+    override fun getParents(): Collection<BlockPos> = parents
+
     override fun onRemove() {
-        DependencyAuraNodeUtils.childDisconnectAll(parents, access, this)
+        super<AbstractDependantAuraNode>.onRemove()
         getReceiver()?.recalculateDescendants(hashSetOf())
     }
 

--- a/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/PortalTransmitterAuraNode.kt
@@ -25,7 +25,7 @@ class PortalTransmitterAuraNode(
     private var value: Float,
     parents: Collection<BlockPos>,
     private var valid: Boolean,
-) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, PortalTXAuraNode {
+) : AbstractAuraNode(Type, access, updateListener, pos), DependantAuraNode, PortalTXAuraNode, ValuedAuraNode {
 
     companion object {
         private val NET_PARENT =

--- a/src/main/kotlin/com/github/hotm/auranet/RenderedDependableAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/RenderedDependableAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import net.minecraft.util.math.BlockPos
 import java.util.stream.Stream

--- a/src/main/kotlin/com/github/hotm/auranet/SiphonAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/SiphonAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 import com.github.hotm.util.DimBlockPos
 

--- a/src/main/kotlin/com/github/hotm/auranet/SourceAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/SourceAuraNode.kt
@@ -1,4 +1,4 @@
-package com.github.hotm.world.auranet
+package com.github.hotm.auranet
 
 interface SourceAuraNode : AuraNode {
     fun getSourceAura(): Float

--- a/src/main/kotlin/com/github/hotm/auranet/ValuedAuraNode.kt
+++ b/src/main/kotlin/com/github/hotm/auranet/ValuedAuraNode.kt
@@ -1,0 +1,13 @@
+package com.github.hotm.auranet
+
+/**
+ * An aura node that has a value.
+ */
+interface ValuedAuraNode {
+    /**
+     * Gets the value of this aura node.
+     *
+     * This is generally used by the Aurameter item and some particle effects.
+     */
+    fun getValue(): Float
+}

--- a/src/main/kotlin/com/github/hotm/blockentity/AbstractDependableAuraNodeBlockEntity.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/AbstractDependableAuraNodeBlockEntity.kt
@@ -1,7 +1,7 @@
 package com.github.hotm.blockentity
 
 import com.github.hotm.util.lazyVar
-import com.github.hotm.world.auranet.DependencyAuraNodeUtils
+import com.github.hotm.auranet.DependencyAuraNodeUtils
 import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/blockentity/PortalReceiverAuraNodeBlockEntity.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/PortalReceiverAuraNodeBlockEntity.kt
@@ -1,8 +1,8 @@
 package com.github.hotm.blockentity
 
 import com.github.hotm.util.lazyVar
-import com.github.hotm.world.auranet.AuraNodeUtils
-import com.github.hotm.world.auranet.PortalReceiverAuraNode
+import com.github.hotm.auranet.AuraNodeUtils
+import com.github.hotm.auranet.PortalReceiverAuraNode
 import net.minecraft.block.BlockState
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/blockentity/PortalTransmitterAuraNodeBlockEntity.kt
+++ b/src/main/kotlin/com/github/hotm/blockentity/PortalTransmitterAuraNodeBlockEntity.kt
@@ -1,8 +1,8 @@
 package com.github.hotm.blockentity
 
 import com.github.hotm.util.lazyVar
-import com.github.hotm.world.auranet.AuraNodeUtils
-import com.github.hotm.world.auranet.PortalTransmitterAuraNode
+import com.github.hotm.auranet.AuraNodeUtils
+import com.github.hotm.auranet.PortalTransmitterAuraNode
 import net.minecraft.block.BlockState
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.nbt.NbtCompound

--- a/src/main/kotlin/com/github/hotm/blocks/AbstractAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/AbstractAuraNodeBlock.kt
@@ -3,8 +3,7 @@ package com.github.hotm.blocks
 import alexiil.mc.lib.attributes.AttributeList
 import alexiil.mc.lib.attributes.AttributeProvider
 import com.github.hotm.mixinapi.StorageUtils
-import com.github.hotm.world.auranet.AttributeProviderAuraNode
-import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.auranet.AttributeProviderAuraNode
 import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/blocks/AbstractAuraNodeBlockWithEntity.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/AbstractAuraNodeBlockWithEntity.kt
@@ -3,7 +3,7 @@ package com.github.hotm.blocks
 import alexiil.mc.lib.attributes.AttributeList
 import alexiil.mc.lib.attributes.AttributeProvider
 import com.github.hotm.mixinapi.StorageUtils
-import com.github.hotm.world.auranet.AttributeProviderAuraNode
+import com.github.hotm.auranet.AttributeProviderAuraNode
 import net.minecraft.block.BlockState
 import net.minecraft.block.BlockWithEntity
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/blocks/AuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/AuraNodeBlock.kt
@@ -1,7 +1,7 @@
 package com.github.hotm.blocks
 
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockState
 import net.minecraft.server.world.ServerWorld

--- a/src/main/kotlin/com/github/hotm/blocks/BasicSiphonAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/BasicSiphonAuraNodeBlock.kt
@@ -5,9 +5,9 @@ import com.github.hotm.blockentity.BasicSiphonAuraNodeBlockEntity
 import com.github.hotm.blockentity.HotMBlockEntities
 import com.github.hotm.mixinapi.StorageUtils
 import com.github.hotm.particle.HotMParticles
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.BasicSiphonAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.BasicSiphonAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockRenderType
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/blocks/BasicSiphonAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/BasicSiphonAuraNodeBlock.kt
@@ -8,6 +8,7 @@ import com.github.hotm.particle.HotMParticles
 import com.github.hotm.auranet.AuraNode
 import com.github.hotm.auranet.AuraNodeType
 import com.github.hotm.auranet.BasicSiphonAuraNode
+import com.github.hotm.auranet.ValuedAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockRenderType
 import net.minecraft.block.BlockState
@@ -71,7 +72,7 @@ class BasicSiphonAuraNodeBlock(settings: Settings) : AbstractAuraNodeBlockWithEn
 
     override fun randomDisplayTick(state: BlockState, world: World, pos: BlockPos, random: Random) {
         val access = StorageUtils.getAuraNetAccess(world)
-        val node = access[pos]
+        val node = access[pos] as? ValuedAuraNode
 
         if (node != null && node.getValue() > 0) {
             val x = pos.x.toDouble() + 0.45 + random.nextDouble() * 0.1

--- a/src/main/kotlin/com/github/hotm/blocks/BasicSourceAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/BasicSourceAuraNodeBlock.kt
@@ -5,6 +5,7 @@ import com.github.hotm.particle.HotMParticles
 import com.github.hotm.auranet.AuraNode
 import com.github.hotm.auranet.AuraNodeType
 import com.github.hotm.auranet.BasicSourceAuraNode
+import com.github.hotm.auranet.ValuedAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockState
 import net.minecraft.block.ShapeContext
@@ -44,7 +45,7 @@ class BasicSourceAuraNodeBlock(settings: Settings) : AbstractAuraNodeBlock(setti
 
     override fun randomDisplayTick(state: BlockState, world: World, pos: BlockPos, random: Random) {
         val access = StorageUtils.getAuraNetAccess(world)
-        val node = access[pos]
+        val node = access[pos] as? ValuedAuraNode
 
         if (node != null && node.getValue() > 0) {
             val x = pos.x.toDouble() + 0.45 + random.nextDouble() * 0.1

--- a/src/main/kotlin/com/github/hotm/blocks/BasicSourceAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/BasicSourceAuraNodeBlock.kt
@@ -2,9 +2,9 @@ package com.github.hotm.blocks
 
 import com.github.hotm.mixinapi.StorageUtils
 import com.github.hotm.particle.HotMParticles
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.BasicSourceAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.BasicSourceAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockState
 import net.minecraft.block.ShapeContext

--- a/src/main/kotlin/com/github/hotm/blocks/CollectorDistributorAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/CollectorDistributorAuraNodeBlock.kt
@@ -3,9 +3,9 @@ package com.github.hotm.blocks
 import com.github.hotm.blockentity.AbstractDependableAuraNodeBlockEntity
 import com.github.hotm.blockentity.CollectorDistributorAuraNodeBlockEntity
 import com.github.hotm.blockentity.HotMBlockEntities
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.CollectorDistributorAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.CollectorDistributorAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockRenderType
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/blocks/PortalReceiverAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/PortalReceiverAuraNodeBlock.kt
@@ -3,10 +3,10 @@ package com.github.hotm.blocks
 import com.github.hotm.blockentity.AbstractDependableAuraNodeBlockEntity
 import com.github.hotm.blockentity.HotMBlockEntities
 import com.github.hotm.blockentity.PortalReceiverAuraNodeBlockEntity
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.PortalAuraNodeUtils
-import com.github.hotm.world.auranet.PortalReceiverAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.PortalAuraNodeUtils
+import com.github.hotm.auranet.PortalReceiverAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockRenderType
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/blocks/PortalTransmitterAuraNodeBlock.kt
+++ b/src/main/kotlin/com/github/hotm/blocks/PortalTransmitterAuraNodeBlock.kt
@@ -2,10 +2,10 @@ package com.github.hotm.blocks
 
 import com.github.hotm.blockentity.HotMBlockEntities
 import com.github.hotm.blockentity.PortalTransmitterAuraNodeBlockEntity
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.PortalAuraNodeUtils
-import com.github.hotm.world.auranet.PortalTransmitterAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.PortalAuraNodeUtils
+import com.github.hotm.auranet.PortalTransmitterAuraNode
 import com.github.hotm.world.auranet.server.ServerAuraNetStorage
 import net.minecraft.block.BlockRenderType
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/client/render/blockentity/SimpleDependableAuraNodeBlockEntityRenderer.kt
+++ b/src/main/kotlin/com/github/hotm/client/render/blockentity/SimpleDependableAuraNodeBlockEntityRenderer.kt
@@ -2,7 +2,7 @@ package com.github.hotm.client.render.blockentity
 
 import com.github.hotm.blockentity.RenderedDependableAuraNodeBlockEntity
 import com.github.hotm.mixinapi.StorageUtils
-import com.github.hotm.world.auranet.RenderedDependableAuraNode
+import com.github.hotm.auranet.RenderedDependableAuraNode
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.render.block.entity.BlockEntityRenderer

--- a/src/main/kotlin/com/github/hotm/items/AuraTunerItem.kt
+++ b/src/main/kotlin/com/github/hotm/items/AuraTunerItem.kt
@@ -5,9 +5,9 @@ import com.github.hotm.HotMConstants.str
 import com.github.hotm.blocks.AuraNodeBlock
 import com.github.hotm.mixinapi.StorageUtils
 import com.github.hotm.util.DimBlockPos
-import com.github.hotm.world.auranet.DependableAuraNode
-import com.github.hotm.world.auranet.DependantAuraNode
-import com.github.hotm.world.auranet.DependencyAuraNodeUtils
+import com.github.hotm.auranet.DependableAuraNode
+import com.github.hotm.auranet.DependantAuraNode
+import com.github.hotm.auranet.DependencyAuraNodeUtils
 import net.minecraft.item.Item
 import net.minecraft.item.ItemUsageContext
 import net.minecraft.nbt.NbtCompound

--- a/src/main/kotlin/com/github/hotm/items/AurameterItem.kt
+++ b/src/main/kotlin/com/github/hotm/items/AurameterItem.kt
@@ -1,6 +1,7 @@
 package com.github.hotm.items
 
 import com.github.hotm.HotMConstants.message
+import com.github.hotm.auranet.ValuedAuraNode
 import com.github.hotm.mixinapi.StorageUtils
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.Item
@@ -34,7 +35,7 @@ class AurameterItem(settings: Settings) : Item(settings), InteractionCanceler {
             } else {
                 val pos = context.blockPos
                 val access = StorageUtils.getAuraNetAccess(world)
-                val node = access[pos]
+                val node = access[pos] as? ValuedAuraNode
 
                 if (node == null) {
                     ActionResult.FAIL

--- a/src/main/kotlin/com/github/hotm/misc/HotMRegistries.kt
+++ b/src/main/kotlin/com/github/hotm/misc/HotMRegistries.kt
@@ -2,8 +2,8 @@ package com.github.hotm.misc
 
 import com.github.hotm.HotMConstants
 import com.github.hotm.util.CardinalDirection
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
 import com.github.hotm.world.gen.feature.segment.FeatureSegmentType
 import com.mojang.serialization.Lifecycle
 import net.minecraft.util.registry.Registry

--- a/src/main/kotlin/com/github/hotm/util/DimBlockPos.kt
+++ b/src/main/kotlin/com/github/hotm/util/DimBlockPos.kt
@@ -2,7 +2,7 @@ package com.github.hotm.util
 
 import com.github.hotm.misc.HotMLog
 import com.github.hotm.mixinapi.StorageUtils
-import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.auranet.AuraNode
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.block.BlockState

--- a/src/main/kotlin/com/github/hotm/world/auranet/AuraNetAccess.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/AuraNetAccess.kt
@@ -1,5 +1,6 @@
 package com.github.hotm.world.auranet
 
+import com.github.hotm.auranet.AuraNode
 import com.github.hotm.util.DimBlockPos
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.ChunkSectionPos

--- a/src/main/kotlin/com/github/hotm/world/auranet/client/ClientAuraNetChunk.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/client/ClientAuraNetChunk.kt
@@ -5,7 +5,7 @@ import alexiil.mc.lib.net.NetByteBuf
 import com.github.hotm.net.sync.ClientSync2ClientData
 import com.github.hotm.world.HotMDimensions
 import com.github.hotm.world.auranet.AuraNetAccess
-import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.auranet.AuraNode
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap
 import net.minecraft.util.math.BlockPos

--- a/src/main/kotlin/com/github/hotm/world/auranet/client/ClientAuraNetStorage.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/client/ClientAuraNetStorage.kt
@@ -4,7 +4,7 @@ import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.NetByteBuf
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.world.auranet.AuraNetAccess
-import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.auranet.AuraNode
 import net.minecraft.client.world.ClientWorld
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.ChunkPos

--- a/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunk.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunk.kt
@@ -7,9 +7,9 @@ import com.github.hotm.config.HotMConfig
 import com.github.hotm.util.CodecUtils
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.world.HotMDimensions
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.SiphonAuraNode
-import com.github.hotm.world.auranet.SourceAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.SiphonAuraNode
+import com.github.hotm.auranet.SourceAuraNode
 import com.google.common.collect.ImmutableList
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder

--- a/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetStorage.kt
+++ b/src/main/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetStorage.kt
@@ -6,7 +6,7 @@ import com.github.hotm.blocks.AuraNodeBlock
 import com.github.hotm.net.HotMNetwork
 import com.github.hotm.util.DimBlockPos
 import com.github.hotm.world.auranet.AuraNetAccess
-import com.github.hotm.world.auranet.AuraNode
+import com.github.hotm.auranet.AuraNode
 import com.github.hotm.world.storage.CustomSerializingRegionBasedStorage
 import com.mojang.datafixers.DataFixer
 import com.mojang.serialization.Codec

--- a/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
+++ b/src/test/kotlin/com/github/hotm/world/auranet/server/ServerAuraNetChunkTests.kt
@@ -2,10 +2,10 @@ package com.github.hotm.world.auranet.server
 
 import com.github.hotm.blocks.AuraNodeBlock
 import com.github.hotm.runInMockCL
-import com.github.hotm.world.auranet.AuraNode
-import com.github.hotm.world.auranet.AuraNodeType
-import com.github.hotm.world.auranet.SiphonAuraNode
-import com.github.hotm.world.auranet.SourceAuraNode
+import com.github.hotm.auranet.AuraNode
+import com.github.hotm.auranet.AuraNodeType
+import com.github.hotm.auranet.SiphonAuraNode
+import com.github.hotm.auranet.SourceAuraNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
This moves much of the aura net classes out of the `world` package. This also changes `AuraNode` so that it is no longer required to have a value.