### PR TITLE
Leyline fix

### DIFF
--- a/src/main/kotlin/com/github/hotm/client/blockmodel/ct/CTModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/ct/CTModelLayer.kt
@@ -2,13 +2,13 @@ package com.github.hotm.client.blockmodel.ct
 
 import com.github.hotm.client.blockmodel.BakedModelLayer
 import com.github.hotm.client.blockmodel.connector.ModelConnector
+import com.github.hotm.client.blockmodel.util.QuadPos
 import com.github.hotm.util.DirectionUtils.texDown
 import com.github.hotm.util.DirectionUtils.texLeft
 import com.github.hotm.util.DirectionUtils.texRight
 import com.github.hotm.util.DirectionUtils.texUp
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext
 import net.minecraft.block.BlockState
 import net.minecraft.client.texture.Sprite
@@ -29,11 +29,6 @@ class CTModelLayer(
     private val connector: ModelConnector,
     private val tintIndex: Int
 ) : BakedModelLayer {
-    private data class QuadPos(val left: Float, val bottom: Float, val right: Float, val top: Float, val depth: Float) {
-        fun emit(emitter: QuadEmitter, face: Direction) {
-            emitter.square(face, left, bottom, right, top, depth)
-        }
-    }
 
     private val depthClamped = clamp(depth, 0.0f, 0.5f)
     private val depthMaxed = depth.coerceAtMost(0.5f)
@@ -60,7 +55,7 @@ class CTModelLayer(
             val indices = getIndices(blockView, pos, normal)
 
             for (corner in 0 until 4) {
-                corners[corner].emit(emitter, normal)
+                corners[corner].emit(emitter, normal, null)
                 emitter.spriteBake(
                     0,
                     sprites[(indices shr (corner * 3)) and 0x7],

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/static/StaticModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/static/StaticModelLayer.kt
@@ -1,11 +1,12 @@
 package com.github.hotm.client.blockmodel.static
 
 import com.github.hotm.client.blockmodel.BakedModelLayer
-import com.github.hotm.client.blockmodel.QuadEmitterUtils
+import com.github.hotm.client.blockmodel.util.QuadPos
 import net.fabricmc.fabric.api.renderer.v1.RendererAccess
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext
 import net.minecraft.block.BlockState
 import net.minecraft.client.render.model.ModelBakeSettings
@@ -13,25 +14,22 @@ import net.minecraft.client.texture.Sprite
 import net.minecraft.item.ItemStack
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
-import net.minecraft.util.math.Vec2f
+import net.minecraft.util.math.MathHelper
 import net.minecraft.world.BlockRenderView
 import java.util.*
 import java.util.function.Supplier
 
 class StaticModelLayer(private val mesh: Mesh) : BakedModelLayer {
     companion object {
-        private val EXTRA_FLAGS_PER_AXIS = arrayOf(
-            0,
-            MutableQuadView.BAKE_FLIP_V,
-            0,
-        )
-
-        private val SPRITE_UV = arrayOf(
-            Vec2f(0f, 0f),
-            Vec2f(0f, 1f),
-            Vec2f(1f, 1f),
-            Vec2f(1f, 0f)
-        )
+        init {
+            println("### PLEASE REMOVE THE COMMENTED OUT PARTS OF StaticModelLayer ###")
+        }
+//        private val SPRITE_UV = arrayOf(
+//            Vec2f(0f, 0f),
+//            Vec2f(0f, 1f),
+//            Vec2f(1f, 1f),
+//            Vec2f(1f, 0f)
+//        )
 
         fun createBlock(
             rotationContainer: ModelBakeSettings,
@@ -40,6 +38,7 @@ class StaticModelLayer(private val mesh: Mesh) : BakedModelLayer {
             cullFaces: Boolean,
             sideDepth: Float,
             faceDepth: Float,
+            quarterFaces: Boolean,
             down: Sprite,
             downTintIndex: Int,
             up: Sprite,
@@ -58,69 +57,131 @@ class StaticModelLayer(private val mesh: Mesh) : BakedModelLayer {
             val emitter = meshBuilder.emitter
 
             for (normal in Direction.values()) {
-                if (rotate) {
-                    QuadEmitterUtils.square(
-                        emitter,
-                        rotationContainer,
-                        normal,
-                        0.0f + sideDepth,
-                        0.0f + sideDepth,
-                        1.0f - sideDepth,
-                        1.0f - sideDepth,
-                        faceDepth
-                    )
-                } else {
-                    emitter.square(
-                        normal,
-                        0.0f + sideDepth,
-                        0.0f + sideDepth,
-                        1.0f - sideDepth,
-                        1.0f - sideDepth,
-                        faceDepth
-                    )
+                val sprite = when (normal) {
+                    Direction.DOWN -> down
+                    Direction.UP -> up
+                    Direction.NORTH -> north
+                    Direction.SOUTH -> south
+                    Direction.WEST -> west
+                    Direction.EAST -> east
+                }
+                val tintIndex = when (normal) {
+                    Direction.DOWN -> downTintIndex
+                    Direction.UP -> upTintIndex
+                    Direction.NORTH -> northTintIndex
+                    Direction.SOUTH -> southTintIndex
+                    Direction.WEST -> westTintIndex
+                    Direction.EAST -> eastTintIndex
                 }
 
-                emitter.spriteColor(0, -1, -1, -1, -1)
-                emitter.material(renderMaterial)
-                emitter.sprite(0, 0, SPRITE_UV[0].x, SPRITE_UV[0].y)
-                emitter.sprite(1, 0, SPRITE_UV[1].x, SPRITE_UV[1].y)
-                emitter.sprite(2, 0, SPRITE_UV[2].x, SPRITE_UV[2].y)
-                emitter.sprite(3, 0, SPRITE_UV[3].x, SPRITE_UV[3].y)
-
-                emitter.colorIndex(
-                    when (normal) {
-                        Direction.DOWN -> downTintIndex
-                        Direction.UP -> upTintIndex
-                        Direction.NORTH -> northTintIndex
-                        Direction.SOUTH -> southTintIndex
-                        Direction.WEST -> westTintIndex
-                        Direction.EAST -> eastTintIndex
-                    }
-                )
-
-                emitter.spriteBake(
-                    0, when (normal) {
-                        Direction.DOWN -> down
-                        Direction.UP -> up
-                        Direction.NORTH -> north
-                        Direction.SOUTH -> south
-                        Direction.WEST -> west
-                        Direction.EAST -> east
-                    }, MutableQuadView.BAKE_NORMALIZED
-                )
-
-                emitter.cullFace(
-                    if (cullFaces) {
-                        Direction.transform(rotationContainer.rotation.matrix, normal)
-                    } else {
-                        null
-                    }
-                )
-
-                emitter.emit()
+                if (quarterFaces) {
+                    buildQuarteredFace(
+                        emitter,
+                        normal,
+                        rotationContainer,
+                        renderMaterial,
+                        rotate,
+                        cullFaces,
+                        sideDepth,
+                        faceDepth,
+                        sprite,
+                        tintIndex
+                    )
+                } else {
+                    buildFace(
+                        emitter,
+                        normal,
+                        rotationContainer,
+                        renderMaterial,
+                        rotate,
+                        cullFaces,
+                        sideDepth,
+                        faceDepth,
+                        sprite,
+                        tintIndex,
+                    )
+                }
             }
 
             return StaticModelLayer(meshBuilder.build())
+        }
+
+        private fun getCorners(sideDepth: Float, faceDepth: Float): Array<QuadPos> {
+            val depthClamped = MathHelper.clamp(sideDepth, 0.0f, 0.5f)
+            val depthMaxed = faceDepth.coerceAtMost(0.5f)
+            return arrayOf(
+                QuadPos(0.0f + depthClamped, 0.0f + depthClamped, 0.5f, 0.5f, depthMaxed),
+                QuadPos(0.5f, 0.0f + depthClamped, 1.0f - depthClamped, 0.5f, depthMaxed),
+                QuadPos(0.0f + depthClamped, 0.5f, 0.5f, 1.0f - depthClamped, depthMaxed),
+                QuadPos(0.5f, 0.5f, 1.0f - depthClamped, 1.0f - depthClamped, depthMaxed)
+            )
+        }
+
+        private fun buildQuarteredFace(
+            emitter: QuadEmitter,
+            normal: Direction,
+            rotationContainer: ModelBakeSettings,
+            renderMaterial: RenderMaterial,
+            rotate: Boolean,
+            cullFaces: Boolean,
+            sideDepth: Float,
+            faceDepth: Float,
+            sprite: Sprite,
+            tintIndex: Int
+        ) {
+            val corners = getCorners(sideDepth, faceDepth)
+            for (corner in corners) {
+                corner.emit(emitter, normal, if (rotate) rotationContainer else null)
+                putQuadSettings(emitter, renderMaterial, tintIndex, sprite, cullFaces, rotationContainer, normal)
+            }
+        }
+
+        private fun buildFace(
+            emitter: QuadEmitter,
+            normal: Direction,
+            rotationContainer: ModelBakeSettings,
+            renderMaterial: RenderMaterial,
+            rotate: Boolean,
+            cullFaces: Boolean,
+            sideDepth: Float,
+            faceDepth: Float,
+            sprite: Sprite,
+            tintIndex: Int,
+        ) {
+            QuadPos(0.0f + sideDepth, 0.0f + sideDepth, 1.0f - sideDepth, 1.0f - sideDepth, faceDepth)
+                .emit(emitter, normal, if (rotate) rotationContainer else null)
+            putQuadSettings(emitter, renderMaterial, tintIndex, sprite, cullFaces, rotationContainer, normal)
+        }
+
+        private fun putQuadSettings(
+            emitter: QuadEmitter,
+            renderMaterial: RenderMaterial,
+            tintIndex: Int,
+            sprite: Sprite,
+            cullFaces: Boolean,
+            rotationContainer: ModelBakeSettings,
+            normal: Direction
+        ) {
+            emitter.spriteColor(0, -1, -1, -1, -1)
+            emitter.material(renderMaterial)
+//            emitter.sprite(0, 0, SPRITE_UV[0].x, SPRITE_UV[0].y)
+//            emitter.sprite(1, 0, SPRITE_UV[1].x, SPRITE_UV[1].y)
+//            emitter.sprite(2, 0, SPRITE_UV[2].x, SPRITE_UV[2].y)
+//            emitter.sprite(3, 0, SPRITE_UV[3].x, SPRITE_UV[3].y)
+
+            emitter.colorIndex(tintIndex)
+
+            emitter.spriteBake(0, sprite, MutableQuadView.BAKE_NORMALIZED)
+
+            emitter.cullFace(
+                if (cullFaces) {
+                    Direction.transform(rotationContainer.rotation.matrix, normal)
+                } else {
+                    null
+                }
+            )
+
+            emitter.emit()
         }
     }
 

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/static/StaticModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/static/StaticModelLayer.kt
@@ -21,16 +21,6 @@ import java.util.function.Supplier
 
 class StaticModelLayer(private val mesh: Mesh) : BakedModelLayer {
     companion object {
-        init {
-            println("### PLEASE REMOVE THE COMMENTED OUT PARTS OF StaticModelLayer ###")
-        }
-//        private val SPRITE_UV = arrayOf(
-//            Vec2f(0f, 0f),
-//            Vec2f(0f, 1f),
-//            Vec2f(1f, 1f),
-//            Vec2f(1f, 0f)
-//        )
-
         fun createBlock(
             rotationContainer: ModelBakeSettings,
             renderMaterial: RenderMaterial,
@@ -164,10 +154,6 @@ class StaticModelLayer(private val mesh: Mesh) : BakedModelLayer {
         ) {
             emitter.spriteColor(0, -1, -1, -1, -1)
             emitter.material(renderMaterial)
-//            emitter.sprite(0, 0, SPRITE_UV[0].x, SPRITE_UV[0].y)
-//            emitter.sprite(1, 0, SPRITE_UV[1].x, SPRITE_UV[1].y)
-//            emitter.sprite(2, 0, SPRITE_UV[2].x, SPRITE_UV[2].y)
-//            emitter.sprite(3, 0, SPRITE_UV[3].x, SPRITE_UV[3].y)
 
             emitter.colorIndex(tintIndex)
 

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticBottomTopModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticBottomTopModelLayer.kt
@@ -25,7 +25,8 @@ class UnbakedStaticBottomTopModelLayer(
     private val material: JsonMaterial,
     private val depth: Float,
     private val cullFaces: Boolean,
-    private val rotate: Boolean
+    private val rotate: Boolean,
+    private val quarterFaces: Boolean,
 ) : UnbakedModelLayer {
     companion object {
         val CODEC: Codec<UnbakedStaticBottomTopModelLayer> =
@@ -37,8 +38,9 @@ class UnbakedStaticBottomTopModelLayer(
                     JsonMaterial.CODEC.optionalFieldOf("material").forGetter { Optional.of(it.material) },
                     Codec.FLOAT.optionalFieldOf("depth").forGetter { Optional.of(it.depth) },
                     Codec.BOOL.optionalFieldOf("cull_faces").forGetter { Optional.of(it.cullFaces) },
-                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) }
-                ).apply(instance) { side, bottom, top, material, depth, cullFaces, rotate ->
+                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) },
+                    Codec.BOOL.optionalFieldOf("quarter_faces").forGetter { Optional.of(it.quarterFaces) }
+                ).apply(instance) { side, bottom, top, material, depth, cullFaces, rotate, quarterFaces ->
                     UnbakedStaticBottomTopModelLayer(
                         side,
                         bottom,
@@ -46,7 +48,8 @@ class UnbakedStaticBottomTopModelLayer(
                         material.orElse(JsonMaterial.DEFAULT),
                         depth.orElse(0.0f),
                         cullFaces.orElse(true),
-                        rotate.orElse(true)
+                        rotate.orElse(true),
+                        quarterFaces.orElse(false)
                     )
                 }
             }
@@ -88,6 +91,7 @@ class UnbakedStaticBottomTopModelLayer(
             cullFaces,
             depthClamped,
             depthMaxed,
+            quarterFaces,
             bottomSprite,
             bottom.tintIndex,
             topSprite,

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticColumnModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticColumnModelLayer.kt
@@ -24,7 +24,8 @@ class UnbakedStaticColumnModelLayer(
     private val material: JsonMaterial,
     private val depth: Float,
     private val cullFaces: Boolean,
-    private val rotate: Boolean
+    private val rotate: Boolean,
+    private val quarterFaces: Boolean,
 ) : UnbakedModelLayer {
     companion object {
         val CODEC: Codec<UnbakedStaticColumnModelLayer> =
@@ -35,15 +36,17 @@ class UnbakedStaticColumnModelLayer(
                     JsonMaterial.CODEC.optionalFieldOf("material").forGetter { Optional.of(it.material) },
                     Codec.FLOAT.optionalFieldOf("depth").forGetter { Optional.of(it.depth) },
                     Codec.BOOL.optionalFieldOf("cull_faces").forGetter { Optional.of(it.cullFaces) },
-                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) }
-                ).apply(instance) { side, end, material, depth, cullFaces, rotate ->
+                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) },
+                    Codec.BOOL.optionalFieldOf("quarter_faces").forGetter { Optional.of(it.quarterFaces) }
+                ).apply(instance) { side, end, material, depth, cullFaces, rotate, quarterFaces ->
                     UnbakedStaticColumnModelLayer(
                         side,
                         end,
                         material.orElse(JsonMaterial.DEFAULT),
                         depth.orElse(0.0f),
                         cullFaces.orElse(true),
-                        rotate.orElse(true)
+                        rotate.orElse(true),
+                        quarterFaces.orElse(false)
                     )
                 }
             }
@@ -83,6 +86,7 @@ class UnbakedStaticColumnModelLayer(
             cullFaces,
             depthClamped,
             depthMaxed,
+            quarterFaces,
             endSprite,
             end.tintIndex,
             endSprite,

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticModelLayer.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/static/UnbakedStaticModelLayer.kt
@@ -23,7 +23,8 @@ class UnbakedStaticModelLayer(
     private val material: JsonMaterial,
     private val depth: Float,
     private val cullFaces: Boolean,
-    private val rotate: Boolean
+    private val rotate: Boolean,
+    private val quarterFaces: Boolean
 ) : UnbakedModelLayer {
     companion object {
         val CODEC: Codec<UnbakedStaticModelLayer> =
@@ -33,14 +34,16 @@ class UnbakedStaticModelLayer(
                     JsonMaterial.CODEC.optionalFieldOf("material").forGetter { Optional.of(it.material) },
                     Codec.FLOAT.optionalFieldOf("depth").forGetter { Optional.of(it.depth) },
                     Codec.BOOL.optionalFieldOf("cull_faces").forGetter { Optional.of(it.cullFaces) },
-                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) }
-                ).apply(instance) { all, material, depth, cullFaces, rotate ->
+                    Codec.BOOL.optionalFieldOf("rotate").forGetter { Optional.of(it.rotate) },
+                    Codec.BOOL.optionalFieldOf("quarter_faces").forGetter { Optional.of(it.quarterFaces) }
+                ).apply(instance) { all, material, depth, cullFaces, rotate, quarterFaces ->
                     UnbakedStaticModelLayer(
                         all,
                         material.orElse(JsonMaterial.DEFAULT),
                         depth.orElse(0.0f),
                         cullFaces.orElse(true),
-                        rotate.orElse(true)
+                        rotate.orElse(true),
+                        quarterFaces.orElse(false)
                     )
                 }
             }
@@ -78,6 +81,7 @@ class UnbakedStaticModelLayer(
             cullFaces,
             depthClamped,
             depthMaxed,
+            quarterFaces,
             allSprite,
             all.tintIndex,
             allSprite,

--- a/src/main/kotlin/com/github/hotm/client/blockmodel/util/QuadPos.kt
+++ b/src/main/kotlin/com/github/hotm/client/blockmodel/util/QuadPos.kt
@@ -1,0 +1,20 @@
+package com.github.hotm.client.blockmodel.util
+
+import com.github.hotm.client.blockmodel.QuadEmitterUtils
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter
+import net.minecraft.client.render.model.ModelBakeSettings
+import net.minecraft.util.math.Direction
+
+data class QuadPos(val left: Float, val bottom: Float, val right: Float, val top: Float, val depth: Float) {
+    fun emit(emitter: QuadEmitter, face: Direction, rotationContainer: ModelBakeSettings?) {
+        if (rotationContainer != null) {
+            QuadEmitterUtils.square(emitter, rotationContainer, face, left, bottom, right, top, depth)
+        } else {
+            emitter.square(face, left, bottom, right, top, depth)
+        }
+        emitter.sprite(0, 0, left, 1.0f - top)
+        emitter.sprite(1, 0, left, 1.0f - bottom)
+        emitter.sprite(2, 0, right, 1.0f - bottom)
+        emitter.sprite(3, 0, right, 1.0f - top)
+    }
+}

--- a/src/main/resources/assets/hotm/models/block/machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/machine_casing_leyline.hotm.json
@@ -14,6 +14,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/machine_casing_leyline.hotm.json
@@ -4,7 +4,8 @@
   "layers": [
     {
       "type": "hotm:static_all",
-      "all": "hotm:block/machine_casing"
+      "all": "hotm:block/machine_casing",
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -18,7 +19,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/plassein_grass_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/plassein_grass_leyline.hotm.json
@@ -29,6 +29,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/plassein_grass_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/plassein_grass_leyline.hotm.json
@@ -4,7 +4,8 @@
   "layers": [
     {
       "type": "hotm:static_all",
-      "all": "hotm:block/surface_machine_casing"
+      "all": "hotm:block/surface_machine_casing",
+      "quarter_faces": true
     },
     {
       "type": "hotm:static_bottom_top",
@@ -19,7 +20,8 @@
       "bottom": "hotm:block/plassein_machine_casing",
       "material": {
         "blend_mode": "cutout"
-      }
+      },
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -33,7 +35,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/plassein_log_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/plassein_log_leyline.hotm.json
@@ -15,6 +15,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/rusted_machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/rusted_machine_casing_leyline.hotm.json
@@ -6,7 +6,8 @@
       "type": "hotm:static_bottom_top",
       "side": "hotm:block/rusted_machine_casing",
       "bottom": "hotm:block/surface_machine_casing",
-      "top": "hotm:block/rusted_machine_casing_top"
+      "top": "hotm:block/rusted_machine_casing_top",
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -20,7 +21,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/rusted_machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/rusted_machine_casing_leyline.hotm.json
@@ -16,6 +16,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/smooth_thinking_stone_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/smooth_thinking_stone_leyline.hotm.json
@@ -14,6 +14,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/smooth_thinking_stone_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/smooth_thinking_stone_leyline.hotm.json
@@ -4,7 +4,8 @@
   "layers": [
     {
       "type": "hotm:static_all",
-      "all": "hotm:block/smooth_thinking_stone"
+      "all": "hotm:block/smooth_thinking_stone",
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -18,7 +19,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/surface_machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/surface_machine_casing_leyline.hotm.json
@@ -14,6 +14,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,

--- a/src/main/resources/assets/hotm/models/block/surface_machine_casing_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/surface_machine_casing_leyline.hotm.json
@@ -4,7 +4,8 @@
   "layers": [
     {
       "type": "hotm:static_all",
-      "all": "hotm:block/surface_machine_casing"
+      "all": "hotm:block/surface_machine_casing",
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -18,7 +19,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/thinking_stone_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/thinking_stone_leyline.hotm.json
@@ -4,7 +4,8 @@
   "layers": [
     {
       "type": "hotm:static_all",
-      "all": "hotm:block/thinking_stone"
+      "all": "hotm:block/thinking_stone",
+      "quarter_faces": true
     },
     {
       "type": "hotm:quarter_connected_texture",
@@ -18,7 +19,6 @@
         "enable_ambient_occlusion": false,
         "emissive": true
       },
-      "depth": -0.001,
       "interior_border": false,
       "connector": "hotm:leyline",
       "tintindex": 0

--- a/src/main/resources/assets/hotm/models/block/thinking_stone_leyline.hotm.json
+++ b/src/main/resources/assets/hotm/models/block/thinking_stone_leyline.hotm.json
@@ -14,6 +14,8 @@
       "corner": "hotm:block/leyline_corner",
       "material": {
         "blend_mode": "cutout",
+        "enable_diffuse_shading": false,
+        "enable_ambient_occlusion": false,
         "emissive": true
       },
       "depth": -0.001,


### PR DESCRIPTION
This PR brings some important improvements to the Connected-Texture engine, allowing connected textures to become decals in most cases. However, this does not satisfy #60 because Plassein Log Leylines cannot use the new method due to their rotated UVs preventing the CT decal from applying properly.