### PR TITLE
Noise Settings DSL

### DIFF
--- a/src/client/kotlin/com/github/hotm/mod/datagen/BlockTagGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/BlockTagGen.kt
@@ -6,15 +6,13 @@ import com.github.hotm.mod.block.HotMBlocks.RUSTED_THINKING_SCRAP
 import com.github.hotm.mod.block.HotMBlocks.THINKING_SCRAP
 import com.github.hotm.mod.block.HotMBlocks.THINKING_STONE
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
-import net.minecraft.block.Block
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider.BlockTagProvider
 import net.minecraft.registry.HolderLookup
-import net.minecraft.registry.RegistryKeys
 import net.minecraft.registry.tag.BlockTags
 
 class BlockTagGen(
     output: FabricDataOutput, registriesFuture: CompletableFuture<HolderLookup.Provider>
-) : FabricTagProvider<Block>(output, RegistryKeys.BLOCK, registriesFuture) {
+) : BlockTagProvider(output, registriesFuture) {
     override fun configure(arg: HolderLookup.Provider) {
         getOrCreateTagBuilder(BlockTags.PICKAXE_MINEABLE).add(
             THINKING_STONE,

--- a/src/client/kotlin/com/github/hotm/mod/datagen/HotMModDataGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/HotMModDataGen.kt
@@ -14,6 +14,8 @@ object HotMModDataGen : DataGeneratorEntrypoint {
         pack.addProvider(::BlockTagGen)
         pack.addProvider(::BlockLootGen)
 
+        pack.addProvider(::NoiseSettingsGen)
+
         Log.LOG.info("[HotM] DataGen complete.")
     }
 }

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -6,13 +6,10 @@ import com.github.hotm.mod.datagen.noise.NoiseSettingsProvider
 import com.github.hotm.mod.datagen.noise.df
 import com.github.hotm.mod.datagen.noise.shiftedNoise
 import com.github.hotm.mod.datagen.noise.yGradient
-import com.github.hotm.mod.util.asBiomeKey
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.minecraft.block.Blocks
 import net.minecraft.util.Identifier
-import net.minecraft.util.math.VerticalSurfaceType
 import net.minecraft.world.gen.YOffset
-import net.minecraft.world.gen.surfacebuilder.SurfaceRules.*
 
 class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output) {
     override fun generate() {
@@ -53,41 +50,30 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
                         .interpolated() * 0.64.df).squeeze()
             }
 
-            surfaceRule(
-                sequence(
-                    condition(
-                        verticalGradient("minecraft:bedrock_floor", YOffset.aboveBottom(0), YOffset.aboveBottom(5)),
-                        block(Blocks.BEDROCK.defaultState)
-                    ),
-                    condition(
-                        biome(
-                            id("thinking_forest").asBiomeKey(),
-                            id("meditating_fields").asBiomeKey()
-                        ),
-                        condition(
-                            water(1, 0),
-                            sequence(
-                                condition(
-                                    stoneDepth(0, false, VerticalSurfaceType.FLOOR),
-                                    block(HotMBlocks.PLASSEIN_THINKING_SCRAP.defaultState)
-                                ),
-                                condition(
-                                    stoneDepth(1, false, VerticalSurfaceType.FLOOR),
-                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
-                                ),
-                                condition(
-                                    stoneDepth(2, false, VerticalSurfaceType.FLOOR),
-                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
-                                ),
-                                condition(
-                                    stoneDepth(3, false, VerticalSurfaceType.FLOOR),
-                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
-                                )
-                            )
-                        )
-                    )
-                )
-            )
+            surfaceRule {
+                conditional {
+                    verticalGradient("minecraft:bedrock_floor", YOffset.aboveBottom(0), YOffset.aboveBottom(5))
+                    block(Blocks.BEDROCK)
+                }
+
+                conditional {
+                    biome {
+                        add(id("thinking_forest"))
+                        add(id("meditating_fields"))
+                    }
+
+                    conditional {
+                        water(1)
+
+                        sequence {
+                            stoneDepthBlock(offset = 0, block = HotMBlocks.PLASSEIN_THINKING_SCRAP)
+                            stoneDepthBlock(offset = 1, block = HotMBlocks.THINKING_SCRAP)
+                            stoneDepthBlock(offset = 2, block = HotMBlocks.THINKING_SCRAP)
+                            stoneDepthBlock(offset = 3, block = HotMBlocks.THINKING_SCRAP)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -33,7 +33,7 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
                 mobGenerationDisabled = false,
                 aquifersEnabled = false,
                 oreVeinsEnabled = false,
-                useLegacyRandomGenerator = true,
+                useLegacyRandomGenerator = false,
                 defaultBlock = HotMBlocks.THINKING_STONE.defaultState,
                 generationShapeConfig = GenerationShapeConfig(-64, 448, 1, 2),
                 noiseRouter = noiseRouter(

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -50,12 +50,12 @@ class NoiseSettingsGen(output: FabricDataOutput, private val lookupProvider: Com
             densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, Identifier("shift_z")))
                 .value()
         val nectereCave3dNoise =
-            densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, Identifier("overworld/base_3d_noise")))
+            densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, id("nectere/cave_3d_noise")))
                 .value()
         val nectereSurface3dNoise = densityFunction.getHolderOrThrow(
             RegistryKey.of(
                 RegistryKeys.DENSITY_FUNCTION,
-                Identifier("overworld/base_3d_noise")
+                id("nectere/surface_3d_noise")
             )
         ).value()
 

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -2,30 +2,20 @@ package com.github.hotm.mod.datagen
 
 import com.github.hotm.mod.Constants.id
 import com.github.hotm.mod.block.HotMBlocks
-import com.github.hotm.mod.datagen.noise.*
+import com.github.hotm.mod.datagen.noise.NoiseSettingsProvider
+import com.github.hotm.mod.datagen.noise.df
+import com.github.hotm.mod.datagen.noise.shiftedNoise
+import com.github.hotm.mod.datagen.noise.yGradient
+import com.github.hotm.mod.util.asBiomeKey
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.minecraft.block.Blocks
-import net.minecraft.registry.RegistryKey
-import net.minecraft.registry.RegistryKeys
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.VerticalSurfaceType
 import net.minecraft.world.gen.YOffset
-import net.minecraft.world.gen.chunk.GenerationShapeConfig
 import net.minecraft.world.gen.surfacebuilder.SurfaceRules.*
 
 class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output) {
     override fun generate() {
-        val upperBoundedCaves =
-            0.9375.df + yGradient(160, 224, 1.0, 0.85) * (id("nectere/cave_3d_noise").df - 0.9375.df)
-        val caves = 2.5.df - 0.15.df + yGradient(-72, -40, 0.0, 1.0) * (upperBoundedCaves - 2.5.df)
-        val upperBoundedSurface =
-            yGradient(192, 256, 1.0, 0.0) * (0.9375.df + id("nectere/surface_3d_noise").df) - 0.9375.df
-        val surface = 2.5.df + yGradient(160, 224, 0.65, 1.0) * (upperBoundedSurface - 2.5.df)
-
-        val finalDensity =
-            ((yGradient(160, 224, 1.0, 0.0) * caves + yGradient(160, 224, 0.0, 1.0) * surface).blendDensity()
-                .interpolated() * 0.64.df).squeeze()
-
         noiseSettings(id("nectere")) {
             seaLevel(0)
             disableMobGeneration(false)
@@ -51,7 +41,16 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
                     shiftZ = "minecraft:shift_z".df
                 )
 
-                finalDensity(finalDensity)
+                val upperBoundedCaves =
+                    0.9375.df + yGradient(160, 224, 1.0, 0.85) * (id("nectere/cave_3d_noise").df - 0.9375.df)
+                val caves = 2.5.df - 0.15.df + yGradient(-72, -40, 0.0, 1.0) * (upperBoundedCaves - 2.5.df)
+                val upperBoundedSurface =
+                    yGradient(192, 256, 1.0, 0.0) * (0.9375.df + id("nectere/surface_3d_noise").df) - 0.9375.df
+                val surface = 2.5.df + yGradient(160, 224, 0.65, 1.0) * (upperBoundedSurface - 2.5.df)
+
+                finalDensity =
+                    ((yGradient(160, 224, 1.0, 0.0) * caves + yGradient(160, 224, 0.0, 1.0) * surface).blendDensity()
+                        .interpolated() * 0.64.df).squeeze()
             }
 
             surfaceRule(
@@ -62,8 +61,8 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
                     ),
                     condition(
                         biome(
-                            RegistryKey.of(RegistryKeys.BIOME, id("thinking_forest")),
-                            RegistryKey.of(RegistryKeys.BIOME, id("meditating_fields"))
+                            id("thinking_forest").asBiomeKey(),
+                            id("meditating_fields").asBiomeKey()
                         ),
                         condition(
                             water(1, 0),

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -1,0 +1,202 @@
+package com.github.hotm.mod.datagen
+
+import com.github.hotm.mod.Constants.id
+import com.github.hotm.mod.Log
+import com.github.hotm.mod.block.HotMBlocks
+import com.mojang.serialization.JsonOps
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
+import net.minecraft.block.Blocks
+import net.minecraft.data.DataPackOutput
+import net.minecraft.data.DataProvider
+import net.minecraft.data.DataWriter
+import net.minecraft.registry.HolderLookup
+import net.minecraft.registry.RegistryKey
+import net.minecraft.registry.RegistryKeys
+import net.minecraft.util.Identifier
+import net.minecraft.util.math.VerticalSurfaceType
+import net.minecraft.world.gen.DensityFunctions.*
+import net.minecraft.world.gen.YOffset
+import net.minecraft.world.gen.chunk.ChunkGeneratorSettings
+import net.minecraft.world.gen.chunk.GenerationShapeConfig
+import net.minecraft.world.gen.noise.NoiseRouter
+import net.minecraft.world.gen.surfacebuilder.SurfaceRules.*
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+
+class NoiseSettingsGen(output: FabricDataOutput, private val lookupProvider: CompletableFuture<HolderLookup.Provider>) :
+    DataProvider {
+    private val resolver = output.createPathResolver(DataPackOutput.Type.DATA_PACK, "noise_settings")
+    private val toWrite = mutableListOf<Pair<Path, ChunkGeneratorSettings>>()
+
+    override fun run(writer: DataWriter): CompletableFuture<*> {
+        return lookupProvider.thenAccept { provider ->
+            generate(provider)
+        }.thenCompose {
+            CompletableFuture.allOf(*(toWrite.asSequence().map { (path, settings) ->
+                val element =
+                    ChunkGeneratorSettings.CODEC.encodeStart(JsonOps.INSTANCE, settings)
+                        .getOrThrow(false, Log.LOG::error)
+                DataProvider.writeAsync(writer, element, path)
+            }.toList().toTypedArray()))
+        }
+    }
+
+    private fun generate(provider: HolderLookup.Provider) {
+        val densityFunction = provider.getLookup(RegistryKeys.DENSITY_FUNCTION).get()
+        val shiftX =
+            densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, Identifier("shift_x")))
+                .value()
+        val shiftZ =
+            densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, Identifier("shift_z")))
+                .value()
+        val nectereCave3dNoise =
+            densityFunction.getHolderOrThrow(RegistryKey.of(RegistryKeys.DENSITY_FUNCTION, Identifier("overworld/base_3d_noise")))
+                .value()
+        val nectereSurface3dNoise = densityFunction.getHolderOrThrow(
+            RegistryKey.of(
+                RegistryKeys.DENSITY_FUNCTION,
+                Identifier("overworld/base_3d_noise")
+            )
+        ).value()
+
+        val noise = provider.getLookup(RegistryKeys.NOISE_PARAMETERS).get()
+        val temperature =
+            noise.getHolderOrThrow(RegistryKey.of(RegistryKeys.NOISE_PARAMETERS, Identifier("temperature")))
+        val vegetation = noise.getHolderOrThrow(RegistryKey.of(RegistryKeys.NOISE_PARAMETERS, Identifier("vegetation")))
+
+        noiseSettings(
+            id("nectere"), ChunkGeneratorSettings(
+                GenerationShapeConfig(-64, 448, 1, 2),
+                HotMBlocks.THINKING_STONE.defaultState,
+                Blocks.WATER.defaultState,
+                NoiseRouter(
+                    zero(),
+                    zero(),
+                    zero(),
+                    zero(),
+                    shiftedNoise2d(
+                        shiftX,
+                        shiftZ,
+                        0.25,
+                        temperature
+                    ),
+                    shiftedNoise2d(
+                        shiftX,
+                        shiftZ,
+                        0.25,
+                        vegetation
+                    ),
+                    zero(),
+                    zero(),
+                    zero(),
+                    zero(),
+                    zero(),
+                    multiply(
+                        constant(0.64),
+                        interpolated(
+                            blendDensity(
+                                add(
+                                    multiply(
+                                        clampedGradientY(160, 224, 1.0, 0.0),
+                                        add(
+                                            constant(-0.15),
+                                            add(
+                                                constant(2.5),
+                                                multiply(
+                                                    clampedGradientY(-72, -40, 0.0, 1.0),
+                                                    add(
+                                                        constant(-2.5),
+                                                        add(
+                                                            constant(0.9375),
+                                                            multiply(
+                                                                clampedGradientY(160, 224, 1.0, 0.85),
+                                                                add(
+                                                                    constant(-0.9375),
+                                                                    nectereCave3dNoise
+                                                                )
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    ),
+                                    multiply(
+                                        clampedGradientY(160, 224, 0.0, 1.0),
+                                        add(
+                                            constant(2.5),
+                                            multiply(
+                                                clampedGradientY(160, 224, 0.65, 1.0),
+                                                add(
+                                                    constant(-2.5),
+                                                    add(
+                                                        constant(-0.9375),
+                                                        multiply(
+                                                            clampedGradientY(192, 256, 1.0, 0.0),
+                                                            add(
+                                                                constant(0.9375),
+                                                                nectereSurface3dNoise
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ).squeeze(),
+                    zero(),
+                    zero(),
+                    zero()
+                ),
+                sequence(
+                    condition(
+                        verticalGradient("minecraft:bedrock_floor", YOffset.aboveBottom(0), YOffset.aboveBottom(5)),
+                        block(Blocks.BEDROCK.defaultState)
+                    ),
+                    condition(
+                        biome(
+                            RegistryKey.of(RegistryKeys.BIOME, id("thinking_forest")),
+                            RegistryKey.of(RegistryKeys.BIOME, id("meditating_fields"))
+                        ),
+                        condition(
+                            water(1, 0),
+                            sequence(
+                                condition(
+                                    stoneDepth(0, false, VerticalSurfaceType.FLOOR),
+                                    block(HotMBlocks.PLASSEIN_THINKING_SCRAP.defaultState)
+                                ),
+                                condition(
+                                    stoneDepth(1, false, VerticalSurfaceType.FLOOR),
+                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
+                                ),
+                                condition(
+                                    stoneDepth(2, false, VerticalSurfaceType.FLOOR),
+                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
+                                ),
+                                condition(
+                                    stoneDepth(3, false, VerticalSurfaceType.FLOOR),
+                                    block(HotMBlocks.THINKING_SCRAP.defaultState)
+                                )
+                            )
+                        )
+                    )
+                ),
+                listOf(),
+                0,
+                false,
+                false,
+                false,
+                true
+            )
+        )
+    }
+
+    private fun noiseSettings(id: Identifier, settings: ChunkGeneratorSettings) {
+        toWrite.add(resolver.resolveJsonFile(id) to settings)
+    }
+
+    override fun getName(): String = "Noise Settings"
+}

--- a/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/NoiseSettingsGen.kt
@@ -26,32 +26,36 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
             ((yGradient(160, 224, 1.0, 0.0) * caves + yGradient(160, 224, 0.0, 1.0) * surface).blendDensity()
                 .interpolated() * 0.64.df).squeeze()
 
-        noiseSettings(
-            id("nectere"),
-            chunkGeneratorSettings(
-                seaLevel = 0,
-                mobGenerationDisabled = false,
-                aquifersEnabled = false,
-                oreVeinsEnabled = false,
-                useLegacyRandomGenerator = false,
-                defaultBlock = HotMBlocks.THINKING_STONE.defaultState,
-                generationShapeConfig = GenerationShapeConfig(-64, 448, 1, 2),
-                noiseRouter = noiseRouter(
-                    temperature = shiftedNoise(
-                        noise = Identifier("minecraft:temperature"),
-                        xzScale = 0.25,
-                        shiftX = "minecraft:shift_x".df,
-                        shiftZ = "minecraft:shift_z".df
-                    ),
-                    vegetation = shiftedNoise(
-                        noise = Identifier("minecraft:vegetation"),
-                        xzScale = 0.25,
-                        shiftX = "minecraft:shift_x".df,
-                        shiftZ = "minecraft:shift_z".df
-                    ),
-                    fullNoise = finalDensity
-                ),
-                surfaceRule = sequence(
+        noiseSettings(id("nectere")) {
+            seaLevel(0)
+            disableMobGeneration(false)
+            aquifersEnabled(false)
+            oreVeinsEnabled(false)
+            legacyRandomSource(false)
+
+            defaultBlock(HotMBlocks.THINKING_STONE.defaultState)
+
+            noise(-64, 448, 1, 2)
+
+            noiseRouter {
+                temperature = shiftedNoise(
+                    noise = Identifier("minecraft:temperature"),
+                    xzScale = 0.25,
+                    shiftX = "minecraft:shift_x".df,
+                    shiftZ = "minecraft:shift_z".df
+                )
+                vegetation = shiftedNoise(
+                    noise = Identifier("minecraft:vegetation"),
+                    xzScale = 0.25,
+                    shiftX = "minecraft:shift_x".df,
+                    shiftZ = "minecraft:shift_z".df
+                )
+
+                finalDensity(finalDensity)
+            }
+
+            surfaceRule(
+                sequence(
                     condition(
                         verticalGradient("minecraft:bedrock_floor", YOffset.aboveBottom(0), YOffset.aboveBottom(5)),
                         block(Blocks.BEDROCK.defaultState)
@@ -85,6 +89,6 @@ class NoiseSettingsGen(output: FabricDataOutput) : NoiseSettingsProvider(output)
                     )
                 )
             )
-        )
+        }
     }
 }

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
@@ -94,13 +94,15 @@ data class ChunkGeneratorSettingsDsl(
         }
 
         fun noiseRouter(configure: NoiseRouterDsl.Builder.() -> Unit) {
-            val builder = NoiseRouterDsl.builder()
-            builder.configure()
-            noiseRouter = builder.build()
+            noiseRouter = NoiseRouterDsl.builder().apply(configure).build()
         }
 
         fun surfaceRule(prop: SurfaceRules.MaterialRule) {
             surfaceRule = prop
+        }
+
+        fun surfaceRule(configure: SequenceBuilder.() -> Unit) {
+            surfaceRule = SequenceBuilder().apply(configure).build()
         }
 
         fun spawnTargets(prop: List<MultiNoiseUtil.NoiseHypercube>) {

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
@@ -1,0 +1,72 @@
+package com.github.hotm.mod.datagen.noise
+
+import com.mojang.serialization.Codec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.block.BlockState
+import net.minecraft.block.Blocks
+import net.minecraft.world.biome.source.util.MultiNoiseUtil
+import net.minecraft.world.gen.chunk.GenerationShapeConfig
+import net.minecraft.world.gen.surfacebuilder.SurfaceRules
+
+data class ChunkGeneratorSettingsDsl(
+    val generationShapeConfig: GenerationShapeConfig,
+    val defaultBlock: BlockState,
+    val defaultFluid: BlockState,
+    val noiseRouter: NoiseRouterDsl,
+    val surfaceRule: SurfaceRules.MaterialRule,
+    val spawnTarget: List<MultiNoiseUtil.NoiseHypercube>,
+    val seaLevel: Int,
+    val mobGenerationDisabled: Boolean,
+    val aquifersEnabled: Boolean,
+    val oreVeinsEnabled: Boolean,
+    val useLegacyRandomGenerator: Boolean
+) {
+    companion object {
+        val CODEC: Codec<ChunkGeneratorSettingsDsl> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                GenerationShapeConfig.CODEC.fieldOf("noise")
+                    .forGetter(ChunkGeneratorSettingsDsl::generationShapeConfig),
+                BlockState.CODEC.fieldOf("default_block").forGetter(ChunkGeneratorSettingsDsl::defaultBlock),
+                BlockState.CODEC.fieldOf("default_fluid").forGetter(ChunkGeneratorSettingsDsl::defaultFluid),
+                NoiseRouterDsl.CODEC.fieldOf("noise_router").forGetter(ChunkGeneratorSettingsDsl::noiseRouter),
+                SurfaceRules.MaterialRule.CODEC.fieldOf("surface_rule")
+                    .forGetter(ChunkGeneratorSettingsDsl::surfaceRule),
+                MultiNoiseUtil.NoiseHypercube.CODEC.listOf().fieldOf("spawn_target")
+                    .forGetter(ChunkGeneratorSettingsDsl::spawnTarget),
+                Codec.INT.fieldOf("sea_level").forGetter(ChunkGeneratorSettingsDsl::seaLevel),
+                Codec.BOOL.fieldOf("disable_mob_generation")
+                    .forGetter(ChunkGeneratorSettingsDsl::mobGenerationDisabled),
+                Codec.BOOL.fieldOf("aquifers_enabled").forGetter(ChunkGeneratorSettingsDsl::aquifersEnabled),
+                Codec.BOOL.fieldOf("ore_veins_enabled").forGetter(ChunkGeneratorSettingsDsl::oreVeinsEnabled),
+                Codec.BOOL.fieldOf("legacy_random_source")
+                    .forGetter(ChunkGeneratorSettingsDsl::useLegacyRandomGenerator)
+            ).apply(instance, ::ChunkGeneratorSettingsDsl)
+        }
+    }
+}
+
+fun chunkGeneratorSettings(
+    generationShapeConfig: GenerationShapeConfig = GenerationShapeConfig(-64, 384, 1, 2),
+    defaultBlock: BlockState = Blocks.STONE.defaultState,
+    defaultFluid: BlockState = Blocks.WATER.defaultState,
+    noiseRouter: NoiseRouterDsl = noiseRouter(),
+    surfaceRule: SurfaceRules.MaterialRule = SurfaceRules.sequence(),
+    spawnTarget: List<MultiNoiseUtil.NoiseHypercube> = listOf(),
+    seaLevel: Int = 64,
+    mobGenerationDisabled: Boolean = false,
+    aquifersEnabled: Boolean = true,
+    oreVeinsEnabled: Boolean = true,
+    useLegacyRandomGenerator: Boolean = false
+) = ChunkGeneratorSettingsDsl(
+    generationShapeConfig,
+    defaultBlock,
+    defaultFluid,
+    noiseRouter,
+    surfaceRule,
+    spawnTarget,
+    seaLevel,
+    mobGenerationDisabled,
+    aquifersEnabled,
+    oreVeinsEnabled,
+    useLegacyRandomGenerator
+)

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/ChunkGeneratorSettingsDsl.kt
@@ -9,23 +9,23 @@ import net.minecraft.world.gen.chunk.GenerationShapeConfig
 import net.minecraft.world.gen.surfacebuilder.SurfaceRules
 
 data class ChunkGeneratorSettingsDsl(
-    val generationShapeConfig: GenerationShapeConfig,
+    val noise: GenerationShapeConfig,
     val defaultBlock: BlockState,
     val defaultFluid: BlockState,
     val noiseRouter: NoiseRouterDsl,
     val surfaceRule: SurfaceRules.MaterialRule,
     val spawnTarget: List<MultiNoiseUtil.NoiseHypercube>,
     val seaLevel: Int,
-    val mobGenerationDisabled: Boolean,
+    val disableMobGeneration: Boolean,
     val aquifersEnabled: Boolean,
     val oreVeinsEnabled: Boolean,
-    val useLegacyRandomGenerator: Boolean
+    val legacyRandomSource: Boolean
 ) {
     companion object {
         val CODEC: Codec<ChunkGeneratorSettingsDsl> = RecordCodecBuilder.create { instance ->
             instance.group(
                 GenerationShapeConfig.CODEC.fieldOf("noise")
-                    .forGetter(ChunkGeneratorSettingsDsl::generationShapeConfig),
+                    .forGetter(ChunkGeneratorSettingsDsl::noise),
                 BlockState.CODEC.fieldOf("default_block").forGetter(ChunkGeneratorSettingsDsl::defaultBlock),
                 BlockState.CODEC.fieldOf("default_fluid").forGetter(ChunkGeneratorSettingsDsl::defaultFluid),
                 NoiseRouterDsl.CODEC.fieldOf("noise_router").forGetter(ChunkGeneratorSettingsDsl::noiseRouter),
@@ -35,38 +35,122 @@ data class ChunkGeneratorSettingsDsl(
                     .forGetter(ChunkGeneratorSettingsDsl::spawnTarget),
                 Codec.INT.fieldOf("sea_level").forGetter(ChunkGeneratorSettingsDsl::seaLevel),
                 Codec.BOOL.fieldOf("disable_mob_generation")
-                    .forGetter(ChunkGeneratorSettingsDsl::mobGenerationDisabled),
+                    .forGetter(ChunkGeneratorSettingsDsl::disableMobGeneration),
                 Codec.BOOL.fieldOf("aquifers_enabled").forGetter(ChunkGeneratorSettingsDsl::aquifersEnabled),
                 Codec.BOOL.fieldOf("ore_veins_enabled").forGetter(ChunkGeneratorSettingsDsl::oreVeinsEnabled),
                 Codec.BOOL.fieldOf("legacy_random_source")
-                    .forGetter(ChunkGeneratorSettingsDsl::useLegacyRandomGenerator)
+                    .forGetter(ChunkGeneratorSettingsDsl::legacyRandomSource)
             ).apply(instance, ::ChunkGeneratorSettingsDsl)
+        }
+
+        fun builder() = Builder()
+    }
+
+    class Builder(
+        var noise: GenerationShapeConfig = GenerationShapeConfig(-64, 384, 1, 2),
+        var defaultBlock: BlockState = Blocks.STONE.defaultState,
+        var defaultFluid: BlockState = Blocks.WATER.defaultState,
+        var noiseRouter: NoiseRouterDsl = noiseRouter(),
+        var surfaceRule: SurfaceRules.MaterialRule = SurfaceRules.block(Blocks.STONE.defaultState),
+        var spawnTarget: List<MultiNoiseUtil.NoiseHypercube> = listOf(),
+        var seaLevel: Int = 64,
+        var disableMobGeneration: Boolean = false,
+        var aquifersEnabled: Boolean = true,
+        var oreVeinsEnabled: Boolean = true,
+        var legacyRandomSource: Boolean = false
+    ) {
+        fun build() = ChunkGeneratorSettingsDsl(
+            noise,
+            defaultBlock,
+            defaultFluid,
+            noiseRouter,
+            surfaceRule,
+            spawnTarget,
+            seaLevel,
+            disableMobGeneration,
+            aquifersEnabled,
+            oreVeinsEnabled,
+            legacyRandomSource
+        )
+
+        fun noise(noise: GenerationShapeConfig) {
+            this.noise = noise
+        }
+
+        fun noise(minY: Int, height: Int, noiseSizeHorizontal: Int, noiseSizeVertical: Int) {
+            noise = GenerationShapeConfig(minY, height, noiseSizeHorizontal, noiseSizeVertical)
+        }
+
+        fun defaultBlock(state: BlockState) {
+            defaultBlock = state
+        }
+
+        fun defaultFluid(state: BlockState) {
+            defaultFluid = state
+        }
+
+        fun noiseRouter(prop: NoiseRouterDsl) {
+            noiseRouter = prop
+        }
+
+        fun noiseRouter(configure: NoiseRouterDsl.Builder.() -> Unit) {
+            val builder = NoiseRouterDsl.builder()
+            builder.configure()
+            noiseRouter = builder.build()
+        }
+
+        fun surfaceRule(prop: SurfaceRules.MaterialRule) {
+            surfaceRule = prop
+        }
+
+        fun spawnTargets(prop: List<MultiNoiseUtil.NoiseHypercube>) {
+            spawnTarget = prop
+        }
+
+        fun seaLevel(prop: Int) {
+            seaLevel = prop
+        }
+
+        fun disableMobGeneration(prop: Boolean) {
+            disableMobGeneration = prop
+        }
+
+        fun aquifersEnabled(prop: Boolean) {
+            aquifersEnabled = prop
+        }
+
+        fun oreVeinsEnabled(prop: Boolean) {
+            oreVeinsEnabled = prop
+        }
+
+        fun legacyRandomSource(prop: Boolean) {
+            legacyRandomSource = prop
         }
     }
 }
 
 fun chunkGeneratorSettings(
-    generationShapeConfig: GenerationShapeConfig = GenerationShapeConfig(-64, 384, 1, 2),
+    noise: GenerationShapeConfig = GenerationShapeConfig(-64, 384, 1, 2),
     defaultBlock: BlockState = Blocks.STONE.defaultState,
     defaultFluid: BlockState = Blocks.WATER.defaultState,
     noiseRouter: NoiseRouterDsl = noiseRouter(),
     surfaceRule: SurfaceRules.MaterialRule = SurfaceRules.sequence(),
     spawnTarget: List<MultiNoiseUtil.NoiseHypercube> = listOf(),
     seaLevel: Int = 64,
-    mobGenerationDisabled: Boolean = false,
+    disableMobGeneration: Boolean = false,
     aquifersEnabled: Boolean = true,
     oreVeinsEnabled: Boolean = true,
-    useLegacyRandomGenerator: Boolean = false
+    legacyRandomSource: Boolean = false
 ) = ChunkGeneratorSettingsDsl(
-    generationShapeConfig,
+    noise,
     defaultBlock,
     defaultFluid,
     noiseRouter,
     surfaceRule,
     spawnTarget,
     seaLevel,
-    mobGenerationDisabled,
+    disableMobGeneration,
     aquifersEnabled,
     oreVeinsEnabled,
-    useLegacyRandomGenerator
+    legacyRandomSource
 )

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/DensityFunctionDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/DensityFunctionDsl.kt
@@ -1,0 +1,303 @@
+package com.github.hotm.mod.datagen.noise
+
+import java.util.function.Function
+import com.github.hotm.mod.Constants.id
+import com.mojang.datafixers.util.Either
+import com.mojang.serialization.Codec
+import com.mojang.serialization.Lifecycle
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.registry.Registry
+import net.minecraft.registry.RegistryKey
+import net.minecraft.registry.SimpleRegistry
+import net.minecraft.util.Identifier
+
+interface DensityFunctionDsl {
+    companion object {
+        private val REGISTRY = SimpleRegistry<Codec<out DensityFunctionDsl>>(
+            RegistryKey.ofRegistry(id("density_function_dsl")),
+            Lifecycle.experimental()
+        )
+        private val REGISTRY_CODEC = REGISTRY.codec.dispatch(DensityFunctionDsl::codec, Function.identity())
+
+        val CODEC: Codec<DensityFunctionDsl> = Codec.either(
+            Constant.CODEC,
+            Codec.either(Reference.CODEC, REGISTRY_CODEC).xmap(
+                { it.map(Function.identity(), Function.identity()) },
+                {
+                    if (it is Reference) {
+                        Either.left(it)
+                    } else {
+                        Either.right(it)
+                    }
+                }
+            )
+        ).xmap(
+            { it.map(Function.identity(), Function.identity()) },
+            {
+                if (it is Constant) {
+                    Either.left(it)
+                } else {
+                    Either.right(it)
+                }
+            }
+        )
+
+        fun register(id: String, codec: Codec<out DensityFunctionDsl>) {
+            Registry.register(REGISTRY, id, codec)
+        }
+    }
+
+    val codec: Codec<out DensityFunctionDsl>
+
+    /**
+     * Creates a density function that is the multiplication of these two density functions.
+     */
+    infix operator fun times(other: DensityFunctionDsl): DensityFunctionDsl {
+        return if (other is Constant && this is Constant) {
+            Constant(this.value * other.value)
+        } else {
+            Multiply(this, other)
+        }
+    }
+
+    /**
+     * Creates a density function that is the addition of these two density functions.
+     */
+    infix operator fun plus(other: DensityFunctionDsl): DensityFunctionDsl {
+        return if (other is Constant && this is Constant) {
+            Constant(this.value + other.value)
+        } else {
+            Add(this, other)
+        }
+    }
+
+    /**
+     * Creates a density function that is the subtraction of the other from this one.
+     */
+    infix operator fun minus(other: DensityFunctionDsl): DensityFunctionDsl {
+        return if (other is Constant) {
+            if (this is Constant) {
+                Constant(this.value - other.value)
+            } else {
+                this + Constant(-other.value)
+            }
+        } else {
+            this + (-1.0).df * other
+        }
+    }
+
+    /**
+     * Creates a squeeze density function out of this one.
+     */
+    fun squeeze(): DensityFunctionDsl = Squeeze(this)
+
+    /**
+     * Creates an interpolated density function out of this one.
+     */
+    fun interpolated(): DensityFunctionDsl = Interpolated(this)
+
+    /**
+     * Creates a blend-density density function out of this one.
+     */
+    fun blendDensity(): DensityFunctionDsl = BlendDensity(this)
+}
+
+data class Constant(val value: Double) : DensityFunctionDsl {
+    companion object {
+        val CODEC: Codec<Constant> = Codec.DOUBLE.xmap(::Constant, Constant::value)
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+/**
+ * Creates a density function with a constant value.
+ */
+val Double.df: DensityFunctionDsl
+    get() = Constant(this)
+
+/**
+ * Creates a density function with a constant value.
+ */
+val Int.df: DensityFunctionDsl
+    get() = Constant(this.toDouble())
+
+/**
+ * Density function, constant: 0.
+ */
+val zero: DensityFunctionDsl = Constant(0.0)
+
+data class Reference(val ref: Identifier) : DensityFunctionDsl {
+    companion object {
+        val CODEC: Codec<Reference> = Identifier.CODEC.xmap(::Reference, Reference::ref)
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+/**
+ * Creates a reference to a density function specified elsewhere.
+ */
+val Identifier.df: DensityFunctionDsl
+    get() = Reference(this)
+
+/**
+ * Creates a reference to a density function specified elsewhere.
+ */
+val String.df: DensityFunctionDsl
+    get() = Reference(Identifier(this))
+
+private fun <T : DensityFunctionDsl> twoInputCodec(
+    getArg1: (T) -> DensityFunctionDsl, getArg2: (T) -> DensityFunctionDsl,
+    constr: (DensityFunctionDsl, DensityFunctionDsl) -> T
+): Codec<T> {
+    return RecordCodecBuilder.create { instance ->
+        instance.group(
+            DensityFunctionDsl.CODEC.fieldOf("argument1").forGetter(getArg1),
+            DensityFunctionDsl.CODEC.fieldOf("argument2").forGetter(getArg2)
+        ).apply(instance, constr)
+    }
+}
+
+data class Multiply(val arg1: DensityFunctionDsl, val arg2: DensityFunctionDsl) : DensityFunctionDsl {
+    companion object {
+        val CODEC = twoInputCodec(Multiply::arg1, Multiply::arg2, ::Multiply)
+
+        init {
+            DensityFunctionDsl.register("mul", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+data class Add(val arg1: DensityFunctionDsl, val arg2: DensityFunctionDsl) : DensityFunctionDsl {
+    companion object {
+        val CODEC = twoInputCodec(Add::arg1, Add::arg2, ::Add)
+
+        init {
+            DensityFunctionDsl.register("add", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+private fun <T : DensityFunctionDsl> oneInputCodec(
+    getArg: (T) -> DensityFunctionDsl, constr: (DensityFunctionDsl) -> T
+): Codec<T> {
+    return RecordCodecBuilder.create { instance ->
+        instance.group(
+            DensityFunctionDsl.CODEC.fieldOf("argument").forGetter(getArg)
+        ).apply(instance, constr)
+    }
+}
+
+data class Squeeze(val arg: DensityFunctionDsl) : DensityFunctionDsl {
+    companion object {
+        val CODEC = oneInputCodec(Squeeze::arg, ::Squeeze)
+
+        init {
+            DensityFunctionDsl.register("squeeze", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+data class Interpolated(val arg: DensityFunctionDsl) : DensityFunctionDsl {
+    companion object {
+        val CODEC = oneInputCodec(Interpolated::arg, ::Interpolated)
+
+        init {
+            DensityFunctionDsl.register("interpolated", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+data class BlendDensity(val arg: DensityFunctionDsl) : DensityFunctionDsl {
+    companion object {
+        val CODEC = oneInputCodec(BlendDensity::arg, ::BlendDensity)
+
+        init {
+            DensityFunctionDsl.register("blend_density", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+data class YClampedGradient(
+    val fromY: Int,
+    val toY: Int,
+    val fromValue: Double,
+    val toValue: Double
+) : DensityFunctionDsl {
+    companion object {
+        val CODEC: Codec<YClampedGradient> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                Codec.INT.fieldOf("from_y").forGetter(YClampedGradient::fromY),
+                Codec.INT.fieldOf("to_y").forGetter(YClampedGradient::toY),
+                Codec.DOUBLE.fieldOf("from_value").forGetter(YClampedGradient::fromValue),
+                Codec.DOUBLE.fieldOf("to_value").forGetter(YClampedGradient::toValue)
+            ).apply(instance, ::YClampedGradient)
+        }
+
+        init {
+            DensityFunctionDsl.register("y_clamped_gradient", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+fun yGradient(fromY: Int, toY: Int, fromValue: Double, toValue: Double): DensityFunctionDsl =
+    YClampedGradient(fromY, toY, fromValue, toValue)
+
+data class ShiftedNoise(
+    val noise: Identifier,
+    val xzScale: Double,
+    val yScale: Double,
+    val shiftX: DensityFunctionDsl,
+    val shiftY: DensityFunctionDsl,
+    val shiftZ: DensityFunctionDsl
+) : DensityFunctionDsl {
+    companion object {
+        val CODEC: Codec<ShiftedNoise> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                Identifier.CODEC.fieldOf("noise").forGetter(ShiftedNoise::noise),
+                Codec.DOUBLE.fieldOf("xz_scale").forGetter(ShiftedNoise::xzScale),
+                Codec.DOUBLE.fieldOf("y_scale").forGetter(ShiftedNoise::yScale),
+                DensityFunctionDsl.CODEC.fieldOf("shift_x").forGetter(ShiftedNoise::shiftX),
+                DensityFunctionDsl.CODEC.fieldOf("shift_y").forGetter(ShiftedNoise::shiftY),
+                DensityFunctionDsl.CODEC.fieldOf("shift_z").forGetter(ShiftedNoise::shiftZ)
+            ).apply(instance, ::ShiftedNoise)
+        }
+
+        init {
+            DensityFunctionDsl.register("shifted_noise", CODEC)
+        }
+    }
+
+    override val codec: Codec<out DensityFunctionDsl>
+        get() = CODEC
+}
+
+fun shiftedNoise(
+    noise: Identifier,
+    xzScale: Double = 0.0,
+    yScale: Double = 0.0,
+    shiftX: DensityFunctionDsl = zero,
+    shiftY: DensityFunctionDsl = zero,
+    shiftZ: DensityFunctionDsl = zero
+): DensityFunctionDsl = ShiftedNoise(noise, xzScale, yScale, shiftX, shiftY, shiftZ)

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseRouterDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseRouterDsl.kt
@@ -1,0 +1,83 @@
+package com.github.hotm.mod.datagen.noise
+
+import com.mojang.serialization.Codec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+
+data class NoiseRouterDsl(
+    val barrierNoise: DensityFunctionDsl,
+    val fluidLevelFloodNoise: DensityFunctionDsl,
+    val fluidLevelSpreadNoise: DensityFunctionDsl,
+    val lavaNoise: DensityFunctionDsl,
+    val temperature: DensityFunctionDsl,
+    val vegetation: DensityFunctionDsl,
+    val continentalness: DensityFunctionDsl,
+    val erosion: DensityFunctionDsl,
+    val depth: DensityFunctionDsl,
+    val weirdness: DensityFunctionDsl,
+    val initialNonJaggedDensity: DensityFunctionDsl,
+    val fullNoise: DensityFunctionDsl,
+    val veinToggle: DensityFunctionDsl,
+    val veinRidged: DensityFunctionDsl,
+    val veinGap: DensityFunctionDsl
+) {
+    companion object {
+        private fun field(
+            name: String, getter: (NoiseRouterDsl) -> DensityFunctionDsl
+        ): RecordCodecBuilder<NoiseRouterDsl, DensityFunctionDsl> =
+            DensityFunctionDsl.CODEC.fieldOf(name).forGetter(getter)
+
+        val CODEC: Codec<NoiseRouterDsl> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                field("barrier", NoiseRouterDsl::barrierNoise),
+                field("fluid_level_floodedness", NoiseRouterDsl::fluidLevelFloodNoise),
+                field("fluid_level_spread", NoiseRouterDsl::fluidLevelSpreadNoise),
+                field("lava", NoiseRouterDsl::lavaNoise),
+                field("temperature", NoiseRouterDsl::temperature),
+                field("vegetation", NoiseRouterDsl::vegetation),
+                field("continents", NoiseRouterDsl::continentalness),
+                field("erosion", NoiseRouterDsl::erosion),
+                field("depth", NoiseRouterDsl::depth),
+                field("ridges", NoiseRouterDsl::weirdness),
+                field("initial_density_without_jaggedness", NoiseRouterDsl::initialNonJaggedDensity),
+                field("final_density", NoiseRouterDsl::fullNoise),
+                field("vein_toggle", NoiseRouterDsl::veinToggle),
+                field("vein_ridged", NoiseRouterDsl::veinRidged),
+                field("vein_gap", NoiseRouterDsl::veinGap)
+            ).apply(instance, ::NoiseRouterDsl)
+        }
+    }
+}
+
+fun noiseRouter(
+    barrierNoise: DensityFunctionDsl = zero,
+    fluidLevelFloodNoise: DensityFunctionDsl = zero,
+    fluidLevelSpreadNoise: DensityFunctionDsl = zero,
+    lavaNoise: DensityFunctionDsl = zero,
+    temperature: DensityFunctionDsl = zero,
+    vegetation: DensityFunctionDsl = zero,
+    continentalness: DensityFunctionDsl = zero,
+    erosion: DensityFunctionDsl = zero,
+    depth: DensityFunctionDsl = zero,
+    weirdness: DensityFunctionDsl = zero,
+    initialNonJaggedDensity: DensityFunctionDsl = zero,
+    fullNoise: DensityFunctionDsl = zero,
+    veinToggle: DensityFunctionDsl = zero,
+    veinRidged: DensityFunctionDsl = zero,
+    veinGap: DensityFunctionDsl = zero
+) = NoiseRouterDsl(
+    barrierNoise,
+    fluidLevelFloodNoise,
+    fluidLevelSpreadNoise,
+    lavaNoise,
+    temperature,
+    vegetation,
+    continentalness,
+    erosion,
+    depth,
+    weirdness,
+    initialNonJaggedDensity,
+    fullNoise,
+    veinToggle,
+    veinRidged,
+    veinGap
+)

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseRouterDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseRouterDsl.kt
@@ -4,18 +4,18 @@ import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 
 data class NoiseRouterDsl(
-    val barrierNoise: DensityFunctionDsl,
-    val fluidLevelFloodNoise: DensityFunctionDsl,
-    val fluidLevelSpreadNoise: DensityFunctionDsl,
-    val lavaNoise: DensityFunctionDsl,
+    val barrier: DensityFunctionDsl,
+    val fluidLevelFloodedness: DensityFunctionDsl,
+    val fluidLevelSpread: DensityFunctionDsl,
+    val lava: DensityFunctionDsl,
     val temperature: DensityFunctionDsl,
     val vegetation: DensityFunctionDsl,
     val continentalness: DensityFunctionDsl,
     val erosion: DensityFunctionDsl,
     val depth: DensityFunctionDsl,
     val weirdness: DensityFunctionDsl,
-    val initialNonJaggedDensity: DensityFunctionDsl,
-    val fullNoise: DensityFunctionDsl,
+    val initialDensityWithoutJaggedness: DensityFunctionDsl,
+    val finalDensity: DensityFunctionDsl,
     val veinToggle: DensityFunctionDsl,
     val veinRidged: DensityFunctionDsl,
     val veinGap: DensityFunctionDsl
@@ -28,55 +28,153 @@ data class NoiseRouterDsl(
 
         val CODEC: Codec<NoiseRouterDsl> = RecordCodecBuilder.create { instance ->
             instance.group(
-                field("barrier", NoiseRouterDsl::barrierNoise),
-                field("fluid_level_floodedness", NoiseRouterDsl::fluidLevelFloodNoise),
-                field("fluid_level_spread", NoiseRouterDsl::fluidLevelSpreadNoise),
-                field("lava", NoiseRouterDsl::lavaNoise),
+                field("barrier", NoiseRouterDsl::barrier),
+                field("fluid_level_floodedness", NoiseRouterDsl::fluidLevelFloodedness),
+                field("fluid_level_spread", NoiseRouterDsl::fluidLevelSpread),
+                field("lava", NoiseRouterDsl::lava),
                 field("temperature", NoiseRouterDsl::temperature),
                 field("vegetation", NoiseRouterDsl::vegetation),
                 field("continents", NoiseRouterDsl::continentalness),
                 field("erosion", NoiseRouterDsl::erosion),
                 field("depth", NoiseRouterDsl::depth),
                 field("ridges", NoiseRouterDsl::weirdness),
-                field("initial_density_without_jaggedness", NoiseRouterDsl::initialNonJaggedDensity),
-                field("final_density", NoiseRouterDsl::fullNoise),
+                field("initial_density_without_jaggedness", NoiseRouterDsl::initialDensityWithoutJaggedness),
+                field("final_density", NoiseRouterDsl::finalDensity),
                 field("vein_toggle", NoiseRouterDsl::veinToggle),
                 field("vein_ridged", NoiseRouterDsl::veinRidged),
                 field("vein_gap", NoiseRouterDsl::veinGap)
             ).apply(instance, ::NoiseRouterDsl)
         }
+
+        fun builder() = Builder()
+    }
+
+    class Builder(
+        var barrier: DensityFunctionDsl = zero,
+        var fluidLevelFloodedness: DensityFunctionDsl = zero,
+        var fluidLevelSpread: DensityFunctionDsl = zero,
+        var lava: DensityFunctionDsl = zero,
+        var temperature: DensityFunctionDsl = zero,
+        var vegetation: DensityFunctionDsl = zero,
+        var continentalness: DensityFunctionDsl = zero,
+        var erosion: DensityFunctionDsl = zero,
+        var depth: DensityFunctionDsl = zero,
+        var weirdness: DensityFunctionDsl = zero,
+        var initialDensityWithoutJaggedness: DensityFunctionDsl = zero,
+        var finalDensity: DensityFunctionDsl = zero,
+        var veinToggle: DensityFunctionDsl = zero,
+        var veinRidged: DensityFunctionDsl = zero,
+        var veinGap: DensityFunctionDsl = zero
+    ) {
+        fun build() = NoiseRouterDsl(
+            barrier,
+            fluidLevelFloodedness,
+            fluidLevelSpread,
+            lava,
+            temperature,
+            vegetation,
+            continentalness,
+            erosion,
+            depth,
+            weirdness,
+            initialDensityWithoutJaggedness,
+            finalDensity,
+            veinToggle,
+            veinRidged,
+            veinGap
+        )
+
+        fun barrier(df: DensityFunctionDsl) {
+            barrier = df
+        }
+
+        fun fluidLevelFloodedness(df: DensityFunctionDsl) {
+            fluidLevelFloodedness = df
+        }
+
+        fun fluidLevelSpread(df: DensityFunctionDsl) {
+            fluidLevelSpread = df
+        }
+
+        fun lava(df: DensityFunctionDsl) {
+            lava = df
+        }
+
+        fun temperature(df: DensityFunctionDsl) {
+            temperature = df
+        }
+
+        fun vegetation(df: DensityFunctionDsl) {
+            vegetation = df
+        }
+
+        fun continentalness(df: DensityFunctionDsl) {
+            continentalness = df
+        }
+
+        fun erosion(df: DensityFunctionDsl) {
+            erosion = df
+        }
+
+        fun depth(df: DensityFunctionDsl) {
+            depth = df
+        }
+
+        fun weirdness(df: DensityFunctionDsl) {
+            weirdness = df
+        }
+
+        fun initialDensityWithoutJaggedness(df: DensityFunctionDsl) {
+            initialDensityWithoutJaggedness = df
+        }
+
+        fun finalDensity(df: DensityFunctionDsl) {
+            finalDensity = df
+        }
+
+        fun veinToggle(df: DensityFunctionDsl) {
+            veinToggle = df
+        }
+
+        fun veinRidged(df: DensityFunctionDsl) {
+            veinRidged = df
+        }
+
+        fun veinGap(df: DensityFunctionDsl) {
+            veinGap = df
+        }
     }
 }
 
 fun noiseRouter(
-    barrierNoise: DensityFunctionDsl = zero,
-    fluidLevelFloodNoise: DensityFunctionDsl = zero,
-    fluidLevelSpreadNoise: DensityFunctionDsl = zero,
-    lavaNoise: DensityFunctionDsl = zero,
+    barrier: DensityFunctionDsl = zero,
+    fluidLevelFloodedness: DensityFunctionDsl = zero,
+    fluidLevelSpread: DensityFunctionDsl = zero,
+    lava: DensityFunctionDsl = zero,
     temperature: DensityFunctionDsl = zero,
     vegetation: DensityFunctionDsl = zero,
     continentalness: DensityFunctionDsl = zero,
     erosion: DensityFunctionDsl = zero,
     depth: DensityFunctionDsl = zero,
     weirdness: DensityFunctionDsl = zero,
-    initialNonJaggedDensity: DensityFunctionDsl = zero,
-    fullNoise: DensityFunctionDsl = zero,
+    initialDensityWithoutJaggedness: DensityFunctionDsl = zero,
+    finalDensity: DensityFunctionDsl = zero,
     veinToggle: DensityFunctionDsl = zero,
     veinRidged: DensityFunctionDsl = zero,
     veinGap: DensityFunctionDsl = zero
 ) = NoiseRouterDsl(
-    barrierNoise,
-    fluidLevelFloodNoise,
-    fluidLevelSpreadNoise,
-    lavaNoise,
+    barrier,
+    fluidLevelFloodedness,
+    fluidLevelSpread,
+    lava,
     temperature,
     vegetation,
     continentalness,
     erosion,
     depth,
     weirdness,
-    initialNonJaggedDensity,
-    fullNoise,
+    initialDensityWithoutJaggedness,
+    finalDensity,
     veinToggle,
     veinRidged,
     veinGap

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseSettingsProvider.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseSettingsProvider.kt
@@ -1,0 +1,35 @@
+package com.github.hotm.mod.datagen.noise
+
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import com.github.hotm.mod.Log
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
+import com.mojang.serialization.JsonOps
+import net.minecraft.data.DataPackOutput
+import net.minecraft.data.DataProvider
+import net.minecraft.data.DataWriter
+import net.minecraft.util.Identifier
+
+abstract class NoiseSettingsProvider(output: FabricDataOutput) : DataProvider {
+    private val resolver = output.createPathResolver(DataPackOutput.Type.DATA_PACK, "worldgen/noise_settings")
+    private val toWrite = mutableListOf<Pair<Path, ChunkGeneratorSettingsDsl>>()
+
+    protected fun noiseSettings(id: Identifier, settings: ChunkGeneratorSettingsDsl) {
+        toWrite.add(resolver.resolveJsonFile(id) to settings)
+    }
+
+    abstract fun generate()
+
+    override fun run(writer: DataWriter): CompletableFuture<*> {
+        generate()
+
+        return CompletableFuture.allOf(*(toWrite.asSequence().map { (path, settings) ->
+            val element =
+                ChunkGeneratorSettingsDsl.CODEC.encodeStart(JsonOps.INSTANCE, settings)
+                    .getOrThrow(false, Log.LOG::error)
+            DataProvider.writeAsync(writer, element, path)
+        }.toList().toTypedArray()))
+    }
+
+    override fun getName(): String = "Noise Settings"
+}

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseSettingsProvider.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/NoiseSettingsProvider.kt
@@ -18,6 +18,12 @@ abstract class NoiseSettingsProvider(output: FabricDataOutput) : DataProvider {
         toWrite.add(resolver.resolveJsonFile(id) to settings)
     }
 
+    protected fun noiseSettings(id: Identifier, configure: ChunkGeneratorSettingsDsl.Builder.() -> Unit) {
+        val builder = ChunkGeneratorSettingsDsl.builder()
+        builder.configure()
+        toWrite.add(resolver.resolveJsonFile(id) to builder.build())
+    }
+
     abstract fun generate()
 
     override fun run(writer: DataWriter): CompletableFuture<*> {

--- a/src/client/kotlin/com/github/hotm/mod/datagen/noise/SurfaceRuleDsl.kt
+++ b/src/client/kotlin/com/github/hotm/mod/datagen/noise/SurfaceRuleDsl.kt
@@ -1,0 +1,141 @@
+package com.github.hotm.mod.datagen.noise
+
+import com.github.hotm.mod.util.BlockStateBuilder
+import com.github.hotm.mod.util.blockState
+import net.minecraft.block.Block
+import net.minecraft.block.BlockState
+import net.minecraft.registry.RegistryKey
+import net.minecraft.registry.RegistryKeys
+import net.minecraft.util.Identifier
+import net.minecraft.util.math.VerticalSurfaceType
+import net.minecraft.world.biome.Biome
+import net.minecraft.world.gen.YOffset
+import net.minecraft.world.gen.surfacebuilder.SurfaceRules
+import net.minecraft.world.gen.surfacebuilder.SurfaceRules.MaterialCondition
+import net.minecraft.world.gen.surfacebuilder.SurfaceRules.MaterialRule
+
+interface MaterialRuleBuilder {
+    fun build(): MaterialRule
+}
+
+interface MaterialRuleParentBuilder {
+    fun addChild(rule: MaterialRule)
+
+    fun sequence(configure: SequenceBuilder.() -> Unit) {
+        addChild(SequenceBuilder().apply(configure).build())
+    }
+
+    fun conditional(configure: ConditionalBuilder.() -> Unit) {
+        addChild(ConditionalBuilder().apply(configure).build())
+    }
+
+    fun block(state: BlockState) {
+        addChild(SurfaceRules.block(state))
+    }
+
+    fun block(block: Block) {
+        block(block.defaultState)
+    }
+
+    fun block(block: Block, configure: BlockStateBuilder.() -> Unit) {
+        block(blockState(block, configure))
+    }
+
+    fun stoneDepthBlock(
+        offset: Int = 0, addSurfaceDepth: Boolean = false, secondaryDepthRange: Int = 0,
+        surfaceType: VerticalSurfaceType = VerticalSurfaceType.FLOOR, block: Block
+    ) {
+        conditional {
+            stoneDepth(offset, addSurfaceDepth, secondaryDepthRange, surfaceType)
+            block(block)
+        }
+    }
+
+    fun stoneDepthBlock(
+        offset: Int = 0, addSurfaceDepth: Boolean = false, secondaryDepthRange: Int = 0,
+        surfaceType: VerticalSurfaceType = VerticalSurfaceType.FLOOR, state: BlockState
+    ) {
+        conditional {
+            stoneDepth(offset, addSurfaceDepth, secondaryDepthRange, surfaceType)
+            block(state)
+        }
+    }
+}
+
+class SequenceBuilder : MaterialRuleBuilder, MaterialRuleParentBuilder {
+    private val rules = mutableListOf<MaterialRule>()
+
+    override fun build(): MaterialRule = SurfaceRules.sequence(*rules.toTypedArray())
+
+    override fun addChild(rule: MaterialRule) {
+        rules.add(rule)
+    }
+}
+
+fun interface ConditionBuilder {
+    fun condition(condition: MaterialCondition)
+
+    fun biome(vararg biome: RegistryKey<Biome>) {
+        condition(SurfaceRules.biome(*biome))
+    }
+
+    fun biome(vararg biome: Identifier) {
+        condition(SurfaceRules.biome(*biome.map { RegistryKey.of(RegistryKeys.BIOME, it) }.toTypedArray()))
+    }
+
+    fun biome(configure: BiomeConditionBuilder.() -> Unit) {
+        condition(BiomeConditionBuilder().apply(configure).build())
+    }
+
+    fun stoneDepth(
+        offset: Int = 0, addSurfaceDepth: Boolean = false, secondaryDepthRange: Int = 0,
+        surfaceType: VerticalSurfaceType = VerticalSurfaceType.FLOOR
+    ) {
+        condition(SurfaceRules.stoneDepth(offset, addSurfaceDepth, secondaryDepthRange, surfaceType))
+    }
+
+    val not: ConditionBuilder
+        get() = ConditionBuilder { condition(SurfaceRules.not(it)) }
+
+    fun verticalGradient(randomName: String, trueAtAndBelow: YOffset, falseAtAndAbove: YOffset) {
+        condition(SurfaceRules.verticalGradient(randomName, trueAtAndBelow, falseAtAndAbove))
+    }
+
+    fun water(offset: Int = 0, surfaceDepthMultiplier: Int = 0) {
+        condition(SurfaceRules.water(offset, surfaceDepthMultiplier))
+    }
+}
+
+class ConditionalBuilder : MaterialRuleBuilder, MaterialRuleParentBuilder, ConditionBuilder {
+    private var condition: MaterialCondition? = null
+    private var thenRun: MaterialRule? = null
+
+    override fun condition(condition: MaterialCondition) {
+        this.condition = condition
+    }
+
+    override fun build(): MaterialRule {
+        val condition = condition ?: throw IllegalStateException("No condition has been specified")
+        val thenRun = thenRun ?: throw IllegalStateException("Nothing has been specified for this conditional to run")
+        return SurfaceRules.condition(condition, thenRun)
+    }
+
+    override fun addChild(rule: MaterialRule) {
+        if (thenRun != null) throw IllegalStateException("Conditionals only support one child")
+        thenRun = rule
+    }
+}
+
+class BiomeConditionBuilder {
+    private val biomes = mutableListOf<RegistryKey<Biome>>()
+
+    fun build() = SurfaceRules.biome(*biomes.toTypedArray())
+
+    fun add(biome: RegistryKey<Biome>) {
+        biomes.add(biome)
+    }
+
+    fun add(biome: Identifier) {
+        biomes.add(RegistryKey.of(RegistryKeys.BIOME, biome))
+    }
+}

--- a/src/main/kotlin/com/github/hotm/mod/util/BlockStateDsl.kt
+++ b/src/main/kotlin/com/github/hotm/mod/util/BlockStateDsl.kt
@@ -1,0 +1,19 @@
+package com.github.hotm.mod.util
+
+import net.minecraft.block.Block
+import net.minecraft.block.BlockState
+import net.minecraft.state.property.Property
+
+class BlockStateBuilder(private var state: BlockState) {
+    fun build() = state
+
+    infix fun <T : Comparable<T>, V : T> Property<T>.with(value: V) {
+        state = state.with(this, value)
+    }
+}
+
+fun blockState(state: BlockState, configure: BlockStateBuilder.() -> Unit): BlockState =
+    BlockStateBuilder(state).apply(configure).build()
+
+fun blockState(block: Block, configure: BlockStateBuilder.() -> Unit): BlockState =
+    blockState(block.defaultState, configure)

--- a/src/main/kotlin/com/github/hotm/mod/util/IdentifierUtils.kt
+++ b/src/main/kotlin/com/github/hotm/mod/util/IdentifierUtils.kt
@@ -1,0 +1,8 @@
+package com.github.hotm.mod.util
+
+import net.minecraft.registry.RegistryKey
+import net.minecraft.registry.RegistryKeys
+import net.minecraft.util.Identifier
+import net.minecraft.world.biome.Biome
+
+fun Identifier.asBiomeKey(): RegistryKey<Biome> = RegistryKey.of(RegistryKeys.BIOME, this)

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T18:11:24.752457287	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-05T19:49:14.75442252	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T08:36:12.216886044	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-04T16:11:43.432629795	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T16:11:43.432629795	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-04T16:37:40.474784175	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T03:01:48.076206499	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-04T08:36:12.216886044	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T16:37:40.474784175	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-04T18:05:22.473376824	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
+++ b/src/main/resources-generated/.cache/113ef83d31c4f3c13511646705880ec6ab2694c2
@@ -1,3 +1,3 @@
-// 1.19.4	2023-05-04T18:05:22.473376824	Heart of the Machine/Tags for minecraft:block
+// 1.19.4	2023-05-04T18:11:24.752457287	Heart of the Machine/Tags for minecraft:block
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/mineable/pickaxe.json
 0f07cd955a5619e90c52ed0e068493a22ba36d52 data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,2 +1,2 @@
-// 1.19.4	2023-05-04T16:11:43.432447326	Heart of the Machine/Noise Settings
-34200f7446caeaf5cec57b412512de5ec4114429 data/hotm/worldgen/noise_settings/nectere.json
+// 1.19.4	2023-05-04T16:37:40.474514776	Heart of the Machine/Noise Settings
+f7f4ecefd0b177257f2379f5491fc2dfa1e9c553 data/hotm/worldgen/noise_settings/nectere.json

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,2 +1,2 @@
-// 1.19.4	2023-05-04T18:05:22.47316163	Heart of the Machine/Noise Settings
+// 1.19.4	2023-05-04T18:11:24.751806979	Heart of the Machine/Noise Settings
 f7f4ecefd0b177257f2379f5491fc2dfa1e9c553 data/hotm/worldgen/noise_settings/nectere.json

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,1 +1,2 @@
-// 1.19.4	2023-05-04T08:36:12.216718256	Heart of the Machine/Noise Settings
+// 1.19.4	2023-05-04T16:11:43.432447326	Heart of the Machine/Noise Settings
+34200f7446caeaf5cec57b412512de5ec4114429 data/hotm/worldgen/noise_settings/nectere.json

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,2 +1,2 @@
-// 1.19.4	2023-05-04T16:37:40.474514776	Heart of the Machine/Noise Settings
+// 1.19.4	2023-05-04T18:05:22.47316163	Heart of the Machine/Noise Settings
 f7f4ecefd0b177257f2379f5491fc2dfa1e9c553 data/hotm/worldgen/noise_settings/nectere.json

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,0 +1,1 @@
+// 1.19.4	2023-05-04T08:36:12.216718256	Heart of the Machine/Noise Settings

--- a/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
+++ b/src/main/resources-generated/.cache/24f2d408cc3a0109f5cda7ced12bd920e176ca35
@@ -1,2 +1,2 @@
-// 1.19.4	2023-05-04T18:11:24.751806979	Heart of the Machine/Noise Settings
+// 1.19.4	2023-05-05T19:49:14.754014817	Heart of the Machine/Noise Settings
 f7f4ecefd0b177257f2379f5491fc2dfa1e9c553 data/hotm/worldgen/noise_settings/nectere.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T03:01:48.075181794	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-04T08:36:12.215842198	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T18:11:24.74939029	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-05T19:49:14.752055863	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T08:36:12.215842198	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-04T16:11:43.431631284	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T16:37:40.473396368	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-04T18:05:22.471881901	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T18:05:22.471881901	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-04T18:11:24.74939029	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
+++ b/src/main/resources-generated/.cache/27903d2c2ba04bb0d0c6b5e9c4760eedc2db02a6
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T16:11:43.431631284	Heart of the Machine/Block Loot Tables
+// 1.19.4	2023-05-04T16:37:40.473396368	Heart of the Machine/Block Loot Tables
 66b307a0512d90d249aeac28bd8043371ea7bc4d data/hotm/loot_tables/blocks/rusted_thinking_scrap.json
 8c7293c30e14bb3c1e971f87b8cee756993e2877 data/hotm/loot_tables/blocks/plassein_thinking_scrap.json
 42b62e2699d1b1e392d05059e73df7f95b4cc5b6 data/hotm/loot_tables/blocks/thinking_stone.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,10 +1,10 @@
-// 1.19.4	2023-05-04T16:37:40.474166962	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-04T18:05:22.472807004	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json
-9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
 cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 52f949e769b12415b004a8d783522671163e09a5 assets/hotm/models/item/rusted_thinking_scrap.json
+9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
 4052e75de9ef7b7b5464f6e3c5a914c058576c02 assets/hotm/blockstates/plassein_thinking_scrap.json
 cbfafc9aed18939a713dd4b0598a3a9da2076e30 assets/hotm/models/item/thinking_scrap.json
 27dd103162476b90ab77b8a85775d071ea168441 assets/hotm/models/block/rusted_thinking_scrap.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,10 +1,10 @@
-// 1.19.4	2023-05-04T18:11:24.75105647	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-05T19:49:14.753455468	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json
 9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
-cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 52f949e769b12415b004a8d783522671163e09a5 assets/hotm/models/item/rusted_thinking_scrap.json
+cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 4052e75de9ef7b7b5464f6e3c5a914c058576c02 assets/hotm/blockstates/plassein_thinking_scrap.json
 cbfafc9aed18939a713dd4b0598a3a9da2076e30 assets/hotm/models/item/thinking_scrap.json
 27dd103162476b90ab77b8a85775d071ea168441 assets/hotm/models/block/rusted_thinking_scrap.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,9 +1,9 @@
-// 1.19.4	2023-05-04T16:11:43.432215324	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-04T16:37:40.474166962	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json
-cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
+cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 52f949e769b12415b004a8d783522671163e09a5 assets/hotm/models/item/rusted_thinking_scrap.json
 4052e75de9ef7b7b5464f6e3c5a914c058576c02 assets/hotm/blockstates/plassein_thinking_scrap.json
 cbfafc9aed18939a713dd4b0598a3a9da2076e30 assets/hotm/models/item/thinking_scrap.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T08:36:12.21649782	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-04T16:11:43.432215324	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,10 +1,10 @@
-// 1.19.4	2023-05-04T18:05:22.472807004	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-04T18:11:24.75105647	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json
+9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
 cac6ed5072f66b088ce2aa6e623ce801c5716c55 assets/hotm/blockstates/thinking_stone.json
 52f949e769b12415b004a8d783522671163e09a5 assets/hotm/models/item/rusted_thinking_scrap.json
-9be67b887a6d4fe9d0086ec94ef4d8edab16acce assets/hotm/blockstates/thinking_scrap.json
 4052e75de9ef7b7b5464f6e3c5a914c058576c02 assets/hotm/blockstates/plassein_thinking_scrap.json
 cbfafc9aed18939a713dd4b0598a3a9da2076e30 assets/hotm/models/item/thinking_scrap.json
 27dd103162476b90ab77b8a85775d071ea168441 assets/hotm/models/block/rusted_thinking_scrap.json

--- a/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
+++ b/src/main/resources-generated/.cache/9fca44f25c90445835f1f7d652ce09ba7b82a8b5
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-04T03:01:48.075898114	Heart of the Machine/Model Definitions
+// 1.19.4	2023-05-04T08:36:12.21649782	Heart of the Machine/Model Definitions
 28de17605c33e10394f3c47907c9f5e83626ca58 assets/hotm/blockstates/rusted_thinking_scrap.json
 0c233054f1b33d0373bee946ac380babf02c6b4e assets/hotm/models/block/thinking_stone.json
 cf9da18c0048ed649f68f39e9eb88fc4cac4df05 assets/hotm/models/item/thinking_stone.json

--- a/src/main/resources-generated/data/hotm/worldgen/noise_settings/nectere.json
+++ b/src/main/resources-generated/data/hotm/worldgen/noise_settings/nectere.json
@@ -10,7 +10,7 @@
     }
   },
   "disable_mob_generation": false,
-  "legacy_random_source": true,
+  "legacy_random_source": false,
   "noise": {
     "height": 448,
     "min_y": -64,

--- a/src/main/resources-generated/data/hotm/worldgen/noise_settings/nectere.json
+++ b/src/main/resources-generated/data/hotm/worldgen/noise_settings/nectere.json
@@ -1,9 +1,5 @@
 {
-  "sea_level": 0,
-  "disable_mob_generation": false,
   "aquifers_enabled": false,
-  "ore_veins_enabled": false,
-  "legacy_random_source": true,
   "default_block": {
     "Name": "hotm:thinking_stone"
   },
@@ -13,46 +9,24 @@
       "level": "0"
     }
   },
+  "disable_mob_generation": false,
+  "legacy_random_source": true,
   "noise": {
-    "min_y": -64,
     "height": 448,
+    "min_y": -64,
     "size_horizontal": 1,
     "size_vertical": 2
   },
   "noise_router": {
-    "barrier": 0,
-    "fluid_level_floodedness": 0,
-    "fluid_level_spread": 0,
-    "lava": 0,
-    "temperature": {
-      "type": "minecraft:shifted_noise",
-      "noise": "minecraft:temperature",
-      "xz_scale": 0.25,
-      "y_scale": 0,
-      "shift_x": "minecraft:shift_x",
-      "shift_y": 0,
-      "shift_z": "minecraft:shift_z"
-    },
-    "vegetation": {
-      "type": "minecraft:shifted_noise",
-      "noise": "minecraft:vegetation",
-      "xz_scale": 0.25,
-      "y_scale": 0,
-      "shift_x": "minecraft:shift_x",
-      "shift_y": 0,
-      "shift_z": "minecraft:shift_z"
-    },
-    "continents": 0,
-    "erosion": 0,
-    "depth": 0,
-    "ridges": 0,
-    "initial_density_without_jaggedness": 0,
+    "barrier": 0.0,
+    "continents": 0.0,
+    "depth": 0.0,
+    "erosion": 0.0,
     "final_density": {
       "type": "minecraft:squeeze",
       "argument": {
         "type": "minecraft:mul",
-        "argument1": 0.64,
-        "argument2": {
+        "argument1": {
           "type": "minecraft:interpolated",
           "argument": {
             "type": "minecraft:blend_density",
@@ -62,49 +36,45 @@
                 "type": "minecraft:mul",
                 "argument1": {
                   "type": "minecraft:y_clamped_gradient",
+                  "from_value": 1.0,
                   "from_y": 160,
-                  "to_y": 224,
-                  "from_value": 1,
-                  "to_value": 0
+                  "to_value": 0.0,
+                  "to_y": 224
                 },
                 "argument2": {
                   "type": "minecraft:add",
-                  "argument1": -0.15,
+                  "argument1": 2.35,
                   "argument2": {
-                    "type": "minecraft:add",
-                    "argument1": 2.5,
+                    "type": "minecraft:mul",
+                    "argument1": {
+                      "type": "minecraft:y_clamped_gradient",
+                      "from_value": 0.0,
+                      "from_y": -72,
+                      "to_value": 1.0,
+                      "to_y": -40
+                    },
                     "argument2": {
-                      "type": "minecraft:mul",
+                      "type": "minecraft:add",
                       "argument1": {
-                        "type": "minecraft:y_clamped_gradient",
-                        "from_y": -72,
-                        "to_y": -40,
-                        "from_value": 0,
-                        "to_value": 1
-                      },
-                      "argument2": {
                         "type": "minecraft:add",
-                        "argument1": -2.5,
+                        "argument1": 0.9375,
                         "argument2": {
-                          "type": "minecraft:add",
-                          "argument1": 0.9375,
+                          "type": "minecraft:mul",
+                          "argument1": {
+                            "type": "minecraft:y_clamped_gradient",
+                            "from_value": 1.0,
+                            "from_y": 160,
+                            "to_value": 0.85,
+                            "to_y": 224
+                          },
                           "argument2": {
-                            "type": "minecraft:mul",
-                            "argument1": {
-                              "type": "minecraft:y_clamped_gradient",
-                              "from_y": 160,
-                              "to_y": 224,
-                              "from_value": 1,
-                              "to_value": 0.85
-                            },
-                            "argument2": {
-                              "type": "minecraft:add",
-                              "argument1": -0.9375,
-                              "argument2": "hotm:nectere/cave_3d_noise"
-                            }
+                            "type": "minecraft:add",
+                            "argument1": "hotm:nectere/cave_3d_noise",
+                            "argument2": -0.9375
                           }
                         }
-                      }
+                      },
+                      "argument2": -2.5
                     }
                   }
                 }
@@ -113,10 +83,10 @@
                 "type": "minecraft:mul",
                 "argument1": {
                   "type": "minecraft:y_clamped_gradient",
+                  "from_value": 0.0,
                   "from_y": 160,
-                  "to_y": 224,
-                  "from_value": 0,
-                  "to_value": 1
+                  "to_value": 1.0,
+                  "to_y": 224
                 },
                 "argument2": {
                   "type": "minecraft:add",
@@ -125,46 +95,72 @@
                     "type": "minecraft:mul",
                     "argument1": {
                       "type": "minecraft:y_clamped_gradient",
-                      "from_y": 160,
-                      "to_y": 224,
                       "from_value": 0.65,
-                      "to_value": 1
+                      "from_y": 160,
+                      "to_value": 1.0,
+                      "to_y": 224
                     },
                     "argument2": {
                       "type": "minecraft:add",
-                      "argument1": -2.5,
-                      "argument2": {
+                      "argument1": {
                         "type": "minecraft:add",
-                        "argument1": -0.9375,
-                        "argument2": {
+                        "argument1": {
                           "type": "minecraft:mul",
                           "argument1": {
                             "type": "minecraft:y_clamped_gradient",
+                            "from_value": 1.0,
                             "from_y": 192,
-                            "to_y": 256,
-                            "from_value": 1,
-                            "to_value": 0
+                            "to_value": 0.0,
+                            "to_y": 256
                           },
                           "argument2": {
                             "type": "minecraft:add",
                             "argument1": 0.9375,
                             "argument2": "hotm:nectere/surface_3d_noise"
                           }
-                        }
-                      }
+                        },
+                        "argument2": -0.9375
+                      },
+                      "argument2": -2.5
                     }
                   }
                 }
               }
             }
           }
-        }
+        },
+        "argument2": 0.64
       }
     },
-    "vein_toggle": 0,
-    "vein_ridged": 0,
-    "vein_gap": 0
+    "fluid_level_floodedness": 0.0,
+    "fluid_level_spread": 0.0,
+    "initial_density_without_jaggedness": 0.0,
+    "lava": 0.0,
+    "ridges": 0.0,
+    "temperature": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:temperature",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vegetation": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:vegetation",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vein_gap": 0.0,
+    "vein_ridged": 0.0,
+    "vein_toggle": 0.0
   },
+  "ore_veins_enabled": false,
+  "sea_level": 0,
   "spawn_target": [],
   "surface_rule": {
     "type": "minecraft:sequence",
@@ -173,12 +169,12 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:vertical_gradient",
+          "false_at_and_above": {
+            "above_bottom": 5
+          },
           "random_name": "minecraft:bedrock_floor",
           "true_at_and_below": {
             "above_bottom": 0
-          },
-          "false_at_and_above": {
-            "above_bottom": 5
           }
         },
         "then_run": {
@@ -201,9 +197,9 @@
           "type": "minecraft:condition",
           "if_true": {
             "type": "minecraft:water",
+            "add_stone_depth": false,
             "offset": 1,
-            "surface_depth_multiplier": 0,
-            "add_stone_depth": false
+            "surface_depth_multiplier": 0
           },
           "then_run": {
             "type": "minecraft:sequence",
@@ -212,10 +208,10 @@
                 "type": "minecraft:condition",
                 "if_true": {
                   "type": "minecraft:stone_depth",
-                  "offset": 0,
-                  "surface_type": "floor",
                   "add_surface_depth": false,
-                  "secondary_depth_range": 0
+                  "offset": 0,
+                  "secondary_depth_range": 0,
+                  "surface_type": "floor"
                 },
                 "then_run": {
                   "type": "minecraft:block",
@@ -228,10 +224,10 @@
                 "type": "minecraft:condition",
                 "if_true": {
                   "type": "minecraft:stone_depth",
+                  "add_surface_depth": false,
                   "offset": 1,
-                  "surface_type": "floor",
-                  "add_surface_depth": false,
-                  "secondary_depth_range": 0
+                  "secondary_depth_range": 0,
+                  "surface_type": "floor"
                 },
                 "then_run": {
                   "type": "minecraft:block",
@@ -244,10 +240,10 @@
                 "type": "minecraft:condition",
                 "if_true": {
                   "type": "minecraft:stone_depth",
+                  "add_surface_depth": false,
                   "offset": 2,
-                  "surface_type": "floor",
-                  "add_surface_depth": false,
-                  "secondary_depth_range": 0
+                  "secondary_depth_range": 0,
+                  "surface_type": "floor"
                 },
                 "then_run": {
                   "type": "minecraft:block",
@@ -260,10 +256,10 @@
                 "type": "minecraft:condition",
                 "if_true": {
                   "type": "minecraft:stone_depth",
-                  "offset": 3,
-                  "surface_type": "floor",
                   "add_surface_depth": false,
-                  "secondary_depth_range": 0
+                  "offset": 3,
+                  "secondary_depth_range": 0,
+                  "surface_type": "floor"
                 },
                 "then_run": {
                   "type": "minecraft:block",


### PR DESCRIPTION
# This PR
This PR adds datagen and a DSL for `world/noise_settings` json files. This allows better manipulation of the Nectere world generation, especially the density functions, which can now be described as mathematical expressions instead of a json expression tree.